### PR TITLE
feat: Spring MVC 기본 예외 추가 핸들링

### DIFF
--- a/src/main/java/com/example/exception/playground/common/ErrorCode.java
+++ b/src/main/java/com/example/exception/playground/common/ErrorCode.java
@@ -6,9 +6,12 @@ public enum ErrorCode {
 
     // Common
     INVALID_INPUT(HttpStatus.BAD_REQUEST, "C001", "Invalid input value"),
-    METHOD_NOT_ALLOWED(HttpStatus.METHOD_NOT_ALLOWED, "C002", "Method not allowed"),
-    RESOURCE_NOT_FOUND(HttpStatus.NOT_FOUND, "C003", "Resource not found"),
-    INTERNAL_SERVER_ERROR(HttpStatus.INTERNAL_SERVER_ERROR, "C004", "Internal server error"),
+    MISSING_PARAMETER(HttpStatus.BAD_REQUEST, "C002", "Missing required parameter"),
+    UNSUPPORTED_MEDIA_TYPE(HttpStatus.UNSUPPORTED_MEDIA_TYPE, "C003", "Unsupported media type"),
+    MESSAGE_NOT_READABLE(HttpStatus.BAD_REQUEST, "C004", "Malformed request body"),
+    METHOD_NOT_ALLOWED(HttpStatus.METHOD_NOT_ALLOWED, "C005", "Method not allowed"),
+    RESOURCE_NOT_FOUND(HttpStatus.NOT_FOUND, "C006", "Resource not found"),
+    INTERNAL_SERVER_ERROR(HttpStatus.INTERNAL_SERVER_ERROR, "C999", "Internal server error"),
 
     // Business
     DUPLICATE_RESOURCE(HttpStatus.CONFLICT, "B001", "Duplicate resource exists"),

--- a/src/main/java/com/example/exception/playground/common/GlobalExceptionHandler.java
+++ b/src/main/java/com/example/exception/playground/common/GlobalExceptionHandler.java
@@ -3,8 +3,11 @@ package com.example.exception.playground.common;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.http.ResponseEntity;
+import org.springframework.http.converter.HttpMessageNotReadableException;
+import org.springframework.web.HttpMediaTypeNotSupportedException;
 import org.springframework.web.HttpRequestMethodNotSupportedException;
 import org.springframework.web.bind.MethodArgumentNotValidException;
+import org.springframework.web.bind.MissingServletRequestParameterException;
 import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.bind.annotation.RestControllerAdvice;
 import org.springframework.web.method.annotation.MethodArgumentTypeMismatchException;
@@ -38,6 +41,29 @@ public class GlobalExceptionHandler {
                 e.getRequiredType() != null ? e.getRequiredType().getSimpleName() : "unknown");
         ErrorResponse response = ErrorResponse.of(ErrorCode.INVALID_INPUT, message);
         return ResponseEntity.status(ErrorCode.INVALID_INPUT.getStatus()).body(response);
+    }
+
+    @ExceptionHandler(MissingServletRequestParameterException.class)
+    protected ResponseEntity<ErrorResponse> handleMissingServletRequestParameter(MissingServletRequestParameterException e) {
+        log.warn("Missing parameter: {}", e.getMessage());
+        String message = String.format("Required parameter '%s' of type '%s' is missing",
+                e.getParameterName(), e.getParameterType());
+        ErrorResponse response = ErrorResponse.of(ErrorCode.MISSING_PARAMETER, message);
+        return ResponseEntity.status(ErrorCode.MISSING_PARAMETER.getStatus()).body(response);
+    }
+
+    @ExceptionHandler(HttpMediaTypeNotSupportedException.class)
+    protected ResponseEntity<ErrorResponse> handleHttpMediaTypeNotSupported(HttpMediaTypeNotSupportedException e) {
+        log.warn("Unsupported media type: {}", e.getMessage());
+        ErrorResponse response = ErrorResponse.of(ErrorCode.UNSUPPORTED_MEDIA_TYPE, e.getMessage());
+        return ResponseEntity.status(ErrorCode.UNSUPPORTED_MEDIA_TYPE.getStatus()).body(response);
+    }
+
+    @ExceptionHandler(HttpMessageNotReadableException.class)
+    protected ResponseEntity<ErrorResponse> handleHttpMessageNotReadable(HttpMessageNotReadableException e) {
+        log.warn("Message not readable: {}", e.getMessage());
+        ErrorResponse response = ErrorResponse.of(ErrorCode.MESSAGE_NOT_READABLE);
+        return ResponseEntity.status(ErrorCode.MESSAGE_NOT_READABLE.getStatus()).body(response);
     }
 
     @ExceptionHandler(HttpRequestMethodNotSupportedException.class)

--- a/src/main/java/com/example/exception/playground/sample/SampleController.java
+++ b/src/main/java/com/example/exception/playground/sample/SampleController.java
@@ -33,6 +33,11 @@ public class SampleController {
         return ResponseEntity.ok(Map.of("number", number));
     }
 
+    @GetMapping("/missing-param")
+    public ResponseEntity<Map<String, String>> missingParam(@RequestParam String required) {
+        return ResponseEntity.ok(Map.of("required", required));
+    }
+
     @GetMapping("/unexpected-error")
     public ResponseEntity<Void> unexpectedError() {
         throw new RuntimeException("Something went terribly wrong");

--- a/src/test/java/com/example/exception/playground/common/GlobalExceptionHandlerIntegrationTest.java
+++ b/src/test/java/com/example/exception/playground/common/GlobalExceptionHandlerIntegrationTest.java
@@ -24,7 +24,7 @@ class GlobalExceptionHandlerIntegrationTest {
         mockMvc.perform(get("/api/non-existent"))
                 .andDo(print())
                 .andExpect(status().isNotFound())
-                .andExpect(jsonPath("$.code").value("C003"))
+                .andExpect(jsonPath("$.code").value("C006"))
                 .andExpect(jsonPath("$.status").value(404))
                 .andExpect(jsonPath("$.timestamp").exists());
     }

--- a/src/test/java/com/example/exception/playground/common/GlobalExceptionHandlerTest.java
+++ b/src/test/java/com/example/exception/playground/common/GlobalExceptionHandlerTest.java
@@ -79,7 +79,55 @@ class GlobalExceptionHandlerTest {
             mockMvc.perform(patch("/api/samples/1"))
                     .andDo(print())
                     .andExpect(status().isMethodNotAllowed())
-                    .andExpect(jsonPath("$.code").value("C002"));
+                    .andExpect(jsonPath("$.code").value("C005"));
+        }
+    }
+
+    @Nested
+    @DisplayName("Missing Parameter (MissingServletRequestParameterException)")
+    class MissingParameterTests {
+
+        @Test
+        @DisplayName("missing required query param returns 400")
+        void missingParam() throws Exception {
+            mockMvc.perform(get("/api/samples/missing-param"))
+                    .andDo(print())
+                    .andExpect(status().isBadRequest())
+                    .andExpect(jsonPath("$.code").value("C002"))
+                    .andExpect(jsonPath("$.message").value("Required parameter 'required' of type 'String' is missing"));
+        }
+    }
+
+    @Nested
+    @DisplayName("Unsupported Media Type (HttpMediaTypeNotSupportedException)")
+    class UnsupportedMediaTypeTests {
+
+        @Test
+        @DisplayName("XML content-type on JSON endpoint returns 415")
+        void unsupportedMediaType() throws Exception {
+            mockMvc.perform(post("/api/samples")
+                            .contentType(MediaType.APPLICATION_XML)
+                            .content("<name>test</name>"))
+                    .andDo(print())
+                    .andExpect(status().isUnsupportedMediaType())
+                    .andExpect(jsonPath("$.code").value("C003"));
+        }
+    }
+
+    @Nested
+    @DisplayName("Message Not Readable (HttpMessageNotReadableException)")
+    class MessageNotReadableTests {
+
+        @Test
+        @DisplayName("malformed JSON returns 400")
+        void malformedJson() throws Exception {
+            mockMvc.perform(post("/api/samples")
+                            .contentType(MediaType.APPLICATION_JSON)
+                            .content("{invalid json"))
+                    .andDo(print())
+                    .andExpect(status().isBadRequest())
+                    .andExpect(jsonPath("$.code").value("C004"))
+                    .andExpect(jsonPath("$.message").value("Malformed request body"));
         }
     }
 
@@ -93,7 +141,7 @@ class GlobalExceptionHandlerTest {
             mockMvc.perform(get("/api/samples/0"))
                     .andDo(print())
                     .andExpect(status().isNotFound())
-                    .andExpect(jsonPath("$.code").value("C003"))
+                    .andExpect(jsonPath("$.code").value("C006"))
                     .andExpect(jsonPath("$.message").value("Sample with id 0 not found"));
         }
 
@@ -122,7 +170,7 @@ class GlobalExceptionHandlerTest {
             mockMvc.perform(get("/api/samples/unexpected-error"))
                     .andDo(print())
                     .andExpect(status().isInternalServerError())
-                    .andExpect(jsonPath("$.code").value("C004"))
+                    .andExpect(jsonPath("$.code").value("C999"))
                     .andExpect(jsonPath("$.message").value("Internal server error"));
         }
     }


### PR DESCRIPTION
## Summary
- `MissingServletRequestParameterException` → 필수 쿼리 파라미터 누락 시 400 (C002)
- `HttpMediaTypeNotSupportedException` → 지원하지 않는 Content-Type 시 415 (C003)
- `HttpMessageNotReadableException` → 잘못된 JSON 바디 시 400 (C004)
- ErrorCode 체계 재정비: C001~C006 + C999(Internal Server Error)

## Test plan
- [x] `./gradlew test` 11개 테스트 전체 통과

Closes #5

🤖 Generated with [Claude Code](https://claude.com/claude-code)