### PR TITLE
feat: 에러 응답에 traceId + 디버그 모드(stacktrace) 추가

### DIFF
--- a/src/main/java/com/example/exception/playground/common/ErrorResponse.java
+++ b/src/main/java/com/example/exception/playground/common/ErrorResponse.java
@@ -1,37 +1,85 @@
 package com.example.exception.playground.common;
 
+import com.fasterxml.jackson.annotation.JsonInclude;
+
 import java.time.LocalDateTime;
 import java.util.List;
+import java.util.UUID;
 
+@JsonInclude(JsonInclude.Include.NON_NULL)
 public class ErrorResponse {
 
+    private final String traceId;
     private final String code;
     private final String message;
     private final int status;
     private final LocalDateTime timestamp;
     private final List<FieldError> errors;
+    private final String debugMessage;
+    private final String stackTrace;
 
-    private ErrorResponse(String code, String message, int status, List<FieldError> errors) {
+    private ErrorResponse(String code, String message, int status,
+                          List<FieldError> errors, String debugMessage, String stackTrace) {
+        this.traceId = UUID.randomUUID().toString().substring(0, 8);
         this.code = code;
         this.message = message;
         this.status = status;
         this.timestamp = LocalDateTime.now();
         this.errors = errors;
+        this.debugMessage = debugMessage;
+        this.stackTrace = stackTrace;
     }
 
     public static ErrorResponse of(ErrorCode errorCode) {
         return new ErrorResponse(errorCode.getCode(), errorCode.getMessage(),
-                errorCode.getStatus().value(), List.of());
+                errorCode.getStatus().value(), List.of(), null, null);
     }
 
     public static ErrorResponse of(ErrorCode errorCode, String message) {
         return new ErrorResponse(errorCode.getCode(), message,
-                errorCode.getStatus().value(), List.of());
+                errorCode.getStatus().value(), List.of(), null, null);
     }
 
     public static ErrorResponse of(ErrorCode errorCode, List<FieldError> errors) {
         return new ErrorResponse(errorCode.getCode(), errorCode.getMessage(),
-                errorCode.getStatus().value(), errors);
+                errorCode.getStatus().value(), errors, null, null);
+    }
+
+    public static ErrorResponse withDebug(ErrorCode errorCode, Exception e) {
+        String debugMsg = e.getClass().getSimpleName() + ": " + e.getMessage();
+        String trace = getStackTraceAsString(e);
+        return new ErrorResponse(errorCode.getCode(), errorCode.getMessage(),
+                errorCode.getStatus().value(), List.of(), debugMsg, trace);
+    }
+
+    public static ErrorResponse withDebug(ErrorCode errorCode, String message, Exception e) {
+        String debugMsg = e.getClass().getSimpleName() + ": " + e.getMessage();
+        String trace = getStackTraceAsString(e);
+        return new ErrorResponse(errorCode.getCode(), message,
+                errorCode.getStatus().value(), List.of(), debugMsg, trace);
+    }
+
+    public static ErrorResponse withDebug(ErrorCode errorCode, List<FieldError> errors, Exception e) {
+        String debugMsg = e.getClass().getSimpleName() + ": " + e.getMessage();
+        String trace = getStackTraceAsString(e);
+        return new ErrorResponse(errorCode.getCode(), errorCode.getMessage(),
+                errorCode.getStatus().value(), errors, debugMsg, trace);
+    }
+
+    private static String getStackTraceAsString(Exception e) {
+        StringBuilder sb = new StringBuilder();
+        for (StackTraceElement element : e.getStackTrace()) {
+            sb.append(element.toString()).append("\n");
+            if (sb.length() > 2000) {
+                sb.append("... truncated");
+                break;
+            }
+        }
+        return sb.toString();
+    }
+
+    public String getTraceId() {
+        return traceId;
     }
 
     public String getCode() {
@@ -52,6 +100,14 @@ public class ErrorResponse {
 
     public List<FieldError> getErrors() {
         return errors;
+    }
+
+    public String getDebugMessage() {
+        return debugMessage;
+    }
+
+    public String getStackTrace() {
+        return stackTrace;
     }
 
     public record FieldError(String field, String value, String reason) {

--- a/src/main/java/com/example/exception/playground/common/GlobalExceptionHandler.java
+++ b/src/main/java/com/example/exception/playground/common/GlobalExceptionHandler.java
@@ -2,6 +2,7 @@ package com.example.exception.playground.common;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.http.ResponseEntity;
 import org.springframework.http.converter.HttpMessageNotReadableException;
 import org.springframework.web.HttpMediaTypeNotSupportedException;
@@ -21,6 +22,9 @@ public class GlobalExceptionHandler {
 
     private static final Logger log = LoggerFactory.getLogger(GlobalExceptionHandler.class);
 
+    @Value("${app.debug:false}")
+    private boolean debug;
+
     @ExceptionHandler(MethodArgumentNotValidException.class)
     protected ResponseEntity<ErrorResponse> handleMethodArgumentNotValid(MethodArgumentNotValidException e) {
         log.warn("Validation failed: {}", e.getMessage());
@@ -30,7 +34,9 @@ public class GlobalExceptionHandler {
                         error.getRejectedValue() == null ? "" : error.getRejectedValue().toString(),
                         error.getDefaultMessage()))
                 .toList();
-        ErrorResponse response = ErrorResponse.of(ErrorCode.INVALID_INPUT, fieldErrors);
+        ErrorResponse response = debug
+                ? ErrorResponse.withDebug(ErrorCode.INVALID_INPUT, fieldErrors, e)
+                : ErrorResponse.of(ErrorCode.INVALID_INPUT, fieldErrors);
         return ResponseEntity.status(ErrorCode.INVALID_INPUT.getStatus()).body(response);
     }
 
@@ -39,7 +45,9 @@ public class GlobalExceptionHandler {
         log.warn("Type mismatch: {}", e.getMessage());
         String message = String.format("'%s' should be of type '%s'", e.getName(),
                 e.getRequiredType() != null ? e.getRequiredType().getSimpleName() : "unknown");
-        ErrorResponse response = ErrorResponse.of(ErrorCode.INVALID_INPUT, message);
+        ErrorResponse response = debug
+                ? ErrorResponse.withDebug(ErrorCode.INVALID_INPUT, message, e)
+                : ErrorResponse.of(ErrorCode.INVALID_INPUT, message);
         return ResponseEntity.status(ErrorCode.INVALID_INPUT.getStatus()).body(response);
     }
 
@@ -48,42 +56,54 @@ public class GlobalExceptionHandler {
         log.warn("Missing parameter: {}", e.getMessage());
         String message = String.format("Required parameter '%s' of type '%s' is missing",
                 e.getParameterName(), e.getParameterType());
-        ErrorResponse response = ErrorResponse.of(ErrorCode.MISSING_PARAMETER, message);
+        ErrorResponse response = debug
+                ? ErrorResponse.withDebug(ErrorCode.MISSING_PARAMETER, message, e)
+                : ErrorResponse.of(ErrorCode.MISSING_PARAMETER, message);
         return ResponseEntity.status(ErrorCode.MISSING_PARAMETER.getStatus()).body(response);
     }
 
     @ExceptionHandler(HttpMediaTypeNotSupportedException.class)
     protected ResponseEntity<ErrorResponse> handleHttpMediaTypeNotSupported(HttpMediaTypeNotSupportedException e) {
         log.warn("Unsupported media type: {}", e.getMessage());
-        ErrorResponse response = ErrorResponse.of(ErrorCode.UNSUPPORTED_MEDIA_TYPE, e.getMessage());
+        ErrorResponse response = debug
+                ? ErrorResponse.withDebug(ErrorCode.UNSUPPORTED_MEDIA_TYPE, e.getMessage(), e)
+                : ErrorResponse.of(ErrorCode.UNSUPPORTED_MEDIA_TYPE, e.getMessage());
         return ResponseEntity.status(ErrorCode.UNSUPPORTED_MEDIA_TYPE.getStatus()).body(response);
     }
 
     @ExceptionHandler(HttpMessageNotReadableException.class)
     protected ResponseEntity<ErrorResponse> handleHttpMessageNotReadable(HttpMessageNotReadableException e) {
         log.warn("Message not readable: {}", e.getMessage());
-        ErrorResponse response = ErrorResponse.of(ErrorCode.MESSAGE_NOT_READABLE);
+        ErrorResponse response = debug
+                ? ErrorResponse.withDebug(ErrorCode.MESSAGE_NOT_READABLE, e)
+                : ErrorResponse.of(ErrorCode.MESSAGE_NOT_READABLE);
         return ResponseEntity.status(ErrorCode.MESSAGE_NOT_READABLE.getStatus()).body(response);
     }
 
     @ExceptionHandler(HttpRequestMethodNotSupportedException.class)
     protected ResponseEntity<ErrorResponse> handleHttpRequestMethodNotSupported(HttpRequestMethodNotSupportedException e) {
         log.warn("Method not supported: {}", e.getMessage());
-        ErrorResponse response = ErrorResponse.of(ErrorCode.METHOD_NOT_ALLOWED);
+        ErrorResponse response = debug
+                ? ErrorResponse.withDebug(ErrorCode.METHOD_NOT_ALLOWED, e)
+                : ErrorResponse.of(ErrorCode.METHOD_NOT_ALLOWED);
         return ResponseEntity.status(ErrorCode.METHOD_NOT_ALLOWED.getStatus()).body(response);
     }
 
     @ExceptionHandler(NoResourceFoundException.class)
     protected ResponseEntity<ErrorResponse> handleNoResourceFound(NoResourceFoundException e) {
         log.warn("Resource not found: {}", e.getMessage());
-        ErrorResponse response = ErrorResponse.of(ErrorCode.RESOURCE_NOT_FOUND, e.getMessage());
+        ErrorResponse response = debug
+                ? ErrorResponse.withDebug(ErrorCode.RESOURCE_NOT_FOUND, e.getMessage(), e)
+                : ErrorResponse.of(ErrorCode.RESOURCE_NOT_FOUND, e.getMessage());
         return ResponseEntity.status(ErrorCode.RESOURCE_NOT_FOUND.getStatus()).body(response);
     }
 
     @ExceptionHandler(NoHandlerFoundException.class)
     protected ResponseEntity<ErrorResponse> handleNoHandlerFound(NoHandlerFoundException e) {
         log.warn("No handler found: {}", e.getMessage());
-        ErrorResponse response = ErrorResponse.of(ErrorCode.RESOURCE_NOT_FOUND, e.getMessage());
+        ErrorResponse response = debug
+                ? ErrorResponse.withDebug(ErrorCode.RESOURCE_NOT_FOUND, e.getMessage(), e)
+                : ErrorResponse.of(ErrorCode.RESOURCE_NOT_FOUND, e.getMessage());
         return ResponseEntity.status(ErrorCode.RESOURCE_NOT_FOUND.getStatus()).body(response);
     }
 
@@ -91,14 +111,18 @@ public class GlobalExceptionHandler {
     protected ResponseEntity<ErrorResponse> handleBusinessException(BusinessException e) {
         log.warn("Business exception: {}", e.getMessage());
         ErrorCode errorCode = e.getErrorCode();
-        ErrorResponse response = ErrorResponse.of(errorCode, e.getMessage());
+        ErrorResponse response = debug
+                ? ErrorResponse.withDebug(errorCode, e.getMessage(), e)
+                : ErrorResponse.of(errorCode, e.getMessage());
         return ResponseEntity.status(errorCode.getStatus()).body(response);
     }
 
     @ExceptionHandler(Exception.class)
     protected ResponseEntity<ErrorResponse> handleException(Exception e) {
         log.error("Unexpected error occurred", e);
-        ErrorResponse response = ErrorResponse.of(ErrorCode.INTERNAL_SERVER_ERROR);
+        ErrorResponse response = debug
+                ? ErrorResponse.withDebug(ErrorCode.INTERNAL_SERVER_ERROR, e)
+                : ErrorResponse.of(ErrorCode.INTERNAL_SERVER_ERROR);
         return ResponseEntity.status(ErrorCode.INTERNAL_SERVER_ERROR.getStatus()).body(response);
     }
 }

--- a/src/main/resources/application-dev.yml
+++ b/src/main/resources/application-dev.yml
@@ -1,0 +1,2 @@
+app:
+  debug: true

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -4,3 +4,6 @@ spring:
   web:
     resources:
       add-mappings: false
+
+app:
+  debug: false

--- a/src/test/java/com/example/exception/playground/common/GlobalExceptionHandlerDebugTest.java
+++ b/src/test/java/com/example/exception/playground/common/GlobalExceptionHandlerDebugTest.java
@@ -1,0 +1,97 @@
+package com.example.exception.playground.common;
+
+import com.example.exception.playground.sample.SampleController;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.http.MediaType;
+import org.springframework.test.context.TestPropertySource;
+import org.springframework.test.web.servlet.MockMvc;
+
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
+
+@WebMvcTest(SampleController.class)
+@TestPropertySource(properties = "app.debug=true")
+@DisplayName("Debug Mode - ErrorResponse includes debugMessage and stackTrace")
+class GlobalExceptionHandlerDebugTest {
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @Nested
+    @DisplayName("Validation Error in debug mode")
+    class ValidationDebug {
+
+        @Test
+        @DisplayName("includes debugMessage and stackTrace")
+        void validationWithDebug() throws Exception {
+            mockMvc.perform(post("/api/samples")
+                            .contentType(MediaType.APPLICATION_JSON)
+                            .content("""
+                                    {"name": "", "age": 25}
+                                    """))
+                    .andDo(print())
+                    .andExpect(status().isBadRequest())
+                    .andExpect(jsonPath("$.traceId").exists())
+                    .andExpect(jsonPath("$.debugMessage").exists())
+                    .andExpect(jsonPath("$.stackTrace").exists());
+        }
+    }
+
+    @Nested
+    @DisplayName("Business Exception in debug mode")
+    class BusinessExceptionDebug {
+
+        @Test
+        @DisplayName("NotFoundException includes debug info")
+        void notFoundWithDebug() throws Exception {
+            mockMvc.perform(get("/api/samples/0"))
+                    .andDo(print())
+                    .andExpect(status().isNotFound())
+                    .andExpect(jsonPath("$.code").value("C006"))
+                    .andExpect(jsonPath("$.traceId").exists())
+                    .andExpect(jsonPath("$.debugMessage").value("NotFoundException: Sample with id 0 not found"))
+                    .andExpect(jsonPath("$.stackTrace").exists());
+        }
+    }
+
+    @Nested
+    @DisplayName("Unexpected Error in debug mode")
+    class UnexpectedErrorDebug {
+
+        @Test
+        @DisplayName("RuntimeException includes full debug info")
+        void unexpectedErrorWithDebug() throws Exception {
+            mockMvc.perform(get("/api/samples/unexpected-error"))
+                    .andDo(print())
+                    .andExpect(status().isInternalServerError())
+                    .andExpect(jsonPath("$.code").value("C999"))
+                    .andExpect(jsonPath("$.traceId").exists())
+                    .andExpect(jsonPath("$.debugMessage").value("RuntimeException: Something went terribly wrong"))
+                    .andExpect(jsonPath("$.stackTrace").exists());
+        }
+    }
+
+    @Nested
+    @DisplayName("Malformed JSON in debug mode")
+    class MalformedJsonDebug {
+
+        @Test
+        @DisplayName("includes HttpMessageNotReadableException debug info")
+        void malformedJsonWithDebug() throws Exception {
+            mockMvc.perform(post("/api/samples")
+                            .contentType(MediaType.APPLICATION_JSON)
+                            .content("{invalid json"))
+                    .andDo(print())
+                    .andExpect(status().isBadRequest())
+                    .andExpect(jsonPath("$.code").value("C004"))
+                    .andExpect(jsonPath("$.debugMessage").exists())
+                    .andExpect(jsonPath("$.stackTrace").exists());
+        }
+    }
+}

--- a/src/test/java/com/example/exception/playground/common/GlobalExceptionHandlerTest.java
+++ b/src/test/java/com/example/exception/playground/common/GlobalExceptionHandlerTest.java
@@ -35,7 +35,10 @@ class GlobalExceptionHandlerTest {
                     .andExpect(status().isBadRequest())
                     .andExpect(jsonPath("$.code").value("C001"))
                     .andExpect(jsonPath("$.errors").isArray())
-                    .andExpect(jsonPath("$.errors").isNotEmpty());
+                    .andExpect(jsonPath("$.errors").isNotEmpty())
+                    .andExpect(jsonPath("$.traceId").exists())
+                    .andExpect(jsonPath("$.debugMessage").doesNotExist())
+                    .andExpect(jsonPath("$.stackTrace").doesNotExist());
         }
 
         @Test


### PR DESCRIPTION
## Summary
- ErrorResponse에 `traceId` (UUID 8자리) 항상 포함하여 로그 추적 가능
- `app.debug=true` (dev 프로파일) 시 `debugMessage` + `stackTrace` 포함
- `app.debug=false` (기본/prod) 시 `@JsonInclude(NON_NULL)`로 디버그 필드 제외
- `application-dev.yml` 프로파일 분리

## Test plan
- [x] 기존 테스트: traceId 존재 + debugMessage/stackTrace 미포함 검증
- [x] 디버그 모드 테스트 4개: debugMessage/stackTrace 포함 검증
- [x] `./gradlew test` 15개 전체 통과

Closes #7

🤖 Generated with [Claude Code](https://claude.com/claude-code)