### PR TITLE
feat: 커스텀 예외 확장 - Unauthorized, AccessDenied, BusinessRuleViolation

### DIFF
--- a/src/main/java/com/example/exception/playground/common/AccessDeniedException.java
+++ b/src/main/java/com/example/exception/playground/common/AccessDeniedException.java
@@ -1,0 +1,8 @@
+package com.example.exception.playground.common;
+
+public class AccessDeniedException extends BusinessException {
+
+    public AccessDeniedException(String message) {
+        super(ErrorCode.ACCESS_DENIED, message);
+    }
+}

--- a/src/main/java/com/example/exception/playground/common/BusinessRuleViolationException.java
+++ b/src/main/java/com/example/exception/playground/common/BusinessRuleViolationException.java
@@ -1,0 +1,8 @@
+package com.example.exception.playground.common;
+
+public class BusinessRuleViolationException extends BusinessException {
+
+    public BusinessRuleViolationException(String message) {
+        super(ErrorCode.BUSINESS_RULE_VIOLATION, message);
+    }
+}

--- a/src/main/java/com/example/exception/playground/common/UnauthorizedException.java
+++ b/src/main/java/com/example/exception/playground/common/UnauthorizedException.java
@@ -1,0 +1,8 @@
+package com.example.exception.playground.common;
+
+public class UnauthorizedException extends BusinessException {
+
+    public UnauthorizedException(String message) {
+        super(ErrorCode.UNAUTHORIZED, message);
+    }
+}

--- a/src/main/java/com/example/exception/playground/sample/SampleController.java
+++ b/src/main/java/com/example/exception/playground/sample/SampleController.java
@@ -1,7 +1,10 @@
 package com.example.exception.playground.sample;
 
+import com.example.exception.playground.common.AccessDeniedException;
+import com.example.exception.playground.common.BusinessRuleViolationException;
 import com.example.exception.playground.common.DuplicateResourceException;
 import com.example.exception.playground.common.NotFoundException;
+import com.example.exception.playground.common.UnauthorizedException;
 import jakarta.validation.Valid;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
@@ -36,6 +39,24 @@ public class SampleController {
     @GetMapping("/missing-param")
     public ResponseEntity<Map<String, String>> missingParam(@RequestParam String required) {
         return ResponseEntity.ok(Map.of("required", required));
+    }
+
+    @GetMapping("/unauthorized")
+    public ResponseEntity<Void> unauthorized() {
+        throw new UnauthorizedException("Invalid or expired token");
+    }
+
+    @GetMapping("/access-denied")
+    public ResponseEntity<Void> accessDenied() {
+        throw new AccessDeniedException("Insufficient permissions to access this resource");
+    }
+
+    @PostMapping("/business-rule")
+    public ResponseEntity<Map<String, String>> businessRule(@Valid @RequestBody SampleRequest request) {
+        if (request.age() > 100) {
+            throw new BusinessRuleViolationException("Age cannot exceed 100 for this operation");
+        }
+        return ResponseEntity.ok(Map.of("result", "ok"));
     }
 
     @GetMapping("/unexpected-error")

--- a/src/test/java/com/example/exception/playground/common/GlobalExceptionHandlerTest.java
+++ b/src/test/java/com/example/exception/playground/common/GlobalExceptionHandlerTest.java
@@ -149,6 +149,40 @@ class GlobalExceptionHandlerTest {
         }
 
         @Test
+        @DisplayName("UnauthorizedException returns 401")
+        void unauthorized() throws Exception {
+            mockMvc.perform(get("/api/samples/unauthorized"))
+                    .andDo(print())
+                    .andExpect(status().isUnauthorized())
+                    .andExpect(jsonPath("$.code").value("A001"))
+                    .andExpect(jsonPath("$.message").value("Invalid or expired token"));
+        }
+
+        @Test
+        @DisplayName("AccessDeniedException returns 403")
+        void accessDenied() throws Exception {
+            mockMvc.perform(get("/api/samples/access-denied"))
+                    .andDo(print())
+                    .andExpect(status().isForbidden())
+                    .andExpect(jsonPath("$.code").value("A002"))
+                    .andExpect(jsonPath("$.message").value("Insufficient permissions to access this resource"));
+        }
+
+        @Test
+        @DisplayName("BusinessRuleViolationException returns 422")
+        void businessRuleViolation() throws Exception {
+            mockMvc.perform(post("/api/samples/business-rule")
+                            .contentType(MediaType.APPLICATION_JSON)
+                            .content("""
+                                    {"name": "test", "age": 150}
+                                    """))
+                    .andDo(print())
+                    .andExpect(status().isUnprocessableEntity())
+                    .andExpect(jsonPath("$.code").value("B002"))
+                    .andExpect(jsonPath("$.message").value("Age cannot exceed 100 for this operation"));
+        }
+
+        @Test
         @DisplayName("DuplicateResourceException returns 409")
         void duplicate() throws Exception {
             mockMvc.perform(post("/api/samples")


### PR DESCRIPTION
## Summary
- `UnauthorizedException` (401, A001) - 인증 실패
- `AccessDeniedException` (403, A002) - 인가/권한 부족
- `BusinessRuleViolationException` (422, B002) - 비즈니스 규칙 위반
- 모두 `BusinessException` 상속 → 기존 핸들러에서 자동 처리

## Test plan
- [x] `./gradlew test` 18개 테스트 전체 통과

Closes #9

🤖 Generated with [Claude Code](https://claude.com/claude-code)