### PR TITLE
feat: 요청/응답 로깅 필터 + DispatcherServlet 디버깅 지원

### DIFF
--- a/src/main/java/com/example/exception/playground/common/LoggingFilterConfig.java
+++ b/src/main/java/com/example/exception/playground/common/LoggingFilterConfig.java
@@ -1,0 +1,21 @@
+package com.example.exception.playground.common;
+
+import org.springframework.boot.web.servlet.FilterRegistrationBean;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.context.annotation.Profile;
+import org.springframework.core.Ordered;
+
+@Configuration
+@Profile("dev")
+public class LoggingFilterConfig {
+
+    @Bean
+    public FilterRegistrationBean<RequestResponseLoggingFilter> loggingFilter() {
+        FilterRegistrationBean<RequestResponseLoggingFilter> registration = new FilterRegistrationBean<>();
+        registration.setFilter(new RequestResponseLoggingFilter());
+        registration.addUrlPatterns("/api/*");
+        registration.setOrder(Ordered.HIGHEST_PRECEDENCE);
+        return registration;
+    }
+}

--- a/src/main/java/com/example/exception/playground/common/RequestResponseLoggingFilter.java
+++ b/src/main/java/com/example/exception/playground/common/RequestResponseLoggingFilter.java
@@ -1,0 +1,74 @@
+package com.example.exception.playground.common;
+
+import jakarta.servlet.FilterChain;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.slf4j.MDC;
+import org.springframework.web.filter.OncePerRequestFilter;
+import org.springframework.web.util.ContentCachingRequestWrapper;
+import org.springframework.web.util.ContentCachingResponseWrapper;
+
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import java.util.Collections;
+import java.util.UUID;
+
+public class RequestResponseLoggingFilter extends OncePerRequestFilter {
+
+    private static final Logger log = LoggerFactory.getLogger(RequestResponseLoggingFilter.class);
+    private static final String TRACE_ID = "traceId";
+
+    @Override
+    protected void doFilterInternal(HttpServletRequest request, HttpServletResponse response,
+                                    FilterChain filterChain) throws ServletException, IOException {
+        String traceId = UUID.randomUUID().toString().substring(0, 8);
+        MDC.put(TRACE_ID, traceId);
+
+        ContentCachingRequestWrapper wrappedRequest = new ContentCachingRequestWrapper(request);
+        ContentCachingResponseWrapper wrappedResponse = new ContentCachingResponseWrapper(response);
+
+        long startTime = System.currentTimeMillis();
+
+        try {
+            logRequest(wrappedRequest, traceId);
+            filterChain.doFilter(wrappedRequest, wrappedResponse);
+        } finally {
+            long duration = System.currentTimeMillis() - startTime;
+            logResponse(wrappedRequest, wrappedResponse, traceId, duration);
+            wrappedResponse.copyBodyToResponse();
+            MDC.remove(TRACE_ID);
+        }
+    }
+
+    private void logRequest(ContentCachingRequestWrapper request, String traceId) {
+        StringBuilder headers = new StringBuilder();
+        Collections.list(request.getHeaderNames()).forEach(name ->
+                headers.append(name).append(": ").append(request.getHeader(name)).append(", "));
+
+        log.info("[{}] >>> {} {} | Headers: [{}]",
+                traceId, request.getMethod(), request.getRequestURI(),
+                headers.length() > 2 ? headers.substring(0, headers.length() - 2) : "");
+    }
+
+    private void logResponse(ContentCachingRequestWrapper request, ContentCachingResponseWrapper response,
+                             String traceId, long duration) {
+        int status = response.getStatus();
+        String body = new String(response.getContentAsByteArray(), StandardCharsets.UTF_8);
+
+        String requestBody = new String(request.getContentAsByteArray(), StandardCharsets.UTF_8);
+        if (!requestBody.isBlank()) {
+            log.info("[{}] >>> Request Body: {}", traceId, requestBody);
+        }
+
+        if (status >= 400) {
+            log.warn("[{}] <<< {} {} | Status: {} | {}ms | Body: {}",
+                    traceId, request.getMethod(), request.getRequestURI(), status, duration, body);
+        } else {
+            log.info("[{}] <<< {} {} | Status: {} | {}ms",
+                    traceId, request.getMethod(), request.getRequestURI(), status, duration);
+        }
+    }
+}

--- a/src/test/java/com/example/exception/playground/common/RequestResponseLoggingFilterTest.java
+++ b/src/test/java/com/example/exception/playground/common/RequestResponseLoggingFilterTest.java
@@ -1,0 +1,92 @@
+package com.example.exception.playground.common;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.web.servlet.FilterRegistrationBean;
+import org.springframework.context.ApplicationContext;
+import org.springframework.http.MediaType;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.web.servlet.MockMvc;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+@DisplayName("RequestResponseLoggingFilter")
+class RequestResponseLoggingFilterTest {
+
+    @Nested
+    @DisplayName("dev 프로파일에서 로깅 필터 활성화")
+    @SpringBootTest
+    @AutoConfigureMockMvc
+    @ActiveProfiles("dev")
+    class DevProfileTest {
+
+        @Autowired
+        private MockMvc mockMvc;
+
+        @Autowired
+        private ApplicationContext context;
+
+        @Test
+        @DisplayName("로깅 필터 빈이 등록되어 있다")
+        void filterBeanExists() {
+            assertThat(context.getBeansOfType(FilterRegistrationBean.class))
+                    .isNotEmpty();
+        }
+
+        @Test
+        @DisplayName("정상 요청 시 로깅 필터를 거쳐 200 응답")
+        void successRequestLogged() throws Exception {
+            mockMvc.perform(get("/api/samples/1"))
+                    .andDo(print())
+                    .andExpect(status().isOk())
+                    .andExpect(jsonPath("$.id").value(1));
+        }
+
+        @Test
+        @DisplayName("에러 요청 시 로깅 필터를 거쳐 에러 응답 바디 로깅")
+        void errorRequestLogged() throws Exception {
+            mockMvc.perform(get("/api/samples/0"))
+                    .andDo(print())
+                    .andExpect(status().isNotFound())
+                    .andExpect(jsonPath("$.code").value("C006"))
+                    .andExpect(jsonPath("$.debugMessage").exists());
+        }
+
+        @Test
+        @DisplayName("POST 요청 바디도 로깅")
+        void postRequestBodyLogged() throws Exception {
+            mockMvc.perform(post("/api/samples")
+                            .contentType(MediaType.APPLICATION_JSON)
+                            .content("""
+                                    {"name": "test", "age": 25}
+                                    """))
+                    .andDo(print())
+                    .andExpect(status().isOk());
+        }
+    }
+
+    @Nested
+    @DisplayName("기본 프로파일에서 로깅 필터 비활성화")
+    @SpringBootTest
+    @AutoConfigureMockMvc
+    class DefaultProfileTest {
+
+        @Autowired
+        private ApplicationContext context;
+
+        @Test
+        @DisplayName("로깅 필터 빈이 등록되지 않는다")
+        void filterBeanNotExists() {
+            assertThat(context.getBeansOfType(LoggingFilterConfig.class)).isEmpty();
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- `RequestResponseLoggingFilter` 구현 (OncePerRequestFilter 기반)
  - 요청: Method, URI, Headers 로깅
  - 응답: Status, Duration, Body(에러 시) 로깅
  - MDC traceId로 로그 추적 지원
- `@Profile("dev")`로 dev 프로파일에서만 활성화

## DispatcherServlet 디버깅 핵심 브레이크포인트
1. `DispatcherServlet.doDispatch()` - 요청 진입점
2. `HandlerMapping.getHandler()` - 핸들러 매핑 탐색
3. `HandlerAdapter.handle()` - 핸들러 실행
4. `HandlerExceptionResolverComposite.resolveException()` - 예외 해석
5. `ExceptionHandlerExceptionResolver.doResolveHandlerMethodException()` - @ExceptionHandler 탐색/실행

## Test plan
- [x] dev 프로파일: 필터 빈 등록, 정상/에러/POST 바디 로깅
- [x] 기본 프로파일: 필터 빈 미등록
- [x] `./gradlew test` 23개 전체 통과

Closes #11

🤖 Generated with [Claude Code](https://claude.com/claude-code)