### PR TITLE
fix: MDC traceId 보존 및 로깅 필터 테스트 검증 강화

### DIFF
--- a/src/main/java/com/example/exception/playground/common/RequestResponseLoggingFilter.java
+++ b/src/main/java/com/example/exception/playground/common/RequestResponseLoggingFilter.java
@@ -24,6 +24,7 @@ public class RequestResponseLoggingFilter extends OncePerRequestFilter {
     @Override
     protected void doFilterInternal(HttpServletRequest request, HttpServletResponse response,
                                     FilterChain filterChain) throws ServletException, IOException {
+        String previousTraceId = MDC.get(TRACE_ID);
         String traceId = UUID.randomUUID().toString().substring(0, 8);
         MDC.put(TRACE_ID, traceId);
 
@@ -39,7 +40,11 @@ public class RequestResponseLoggingFilter extends OncePerRequestFilter {
             long duration = System.currentTimeMillis() - startTime;
             logResponse(wrappedRequest, wrappedResponse, traceId, duration);
             wrappedResponse.copyBodyToResponse();
-            MDC.remove(TRACE_ID);
+            if (previousTraceId != null) {
+                MDC.put(TRACE_ID, previousTraceId);
+            } else {
+                MDC.remove(TRACE_ID);
+            }
         }
     }
 

--- a/src/test/java/com/example/exception/playground/common/RequestResponseLoggingFilterTest.java
+++ b/src/test/java/com/example/exception/playground/common/RequestResponseLoggingFilterTest.java
@@ -37,9 +37,11 @@ class RequestResponseLoggingFilterTest {
 
         @Test
         @DisplayName("로깅 필터 빈이 등록되어 있다")
+        @SuppressWarnings("rawtypes")
         void filterBeanExists() {
-            assertThat(context.getBeansOfType(FilterRegistrationBean.class))
-                    .isNotEmpty();
+            boolean hasLoggingFilter = context.getBeansOfType(FilterRegistrationBean.class).values().stream()
+                    .anyMatch(bean -> bean.getFilter() instanceof RequestResponseLoggingFilter);
+            assertThat(hasLoggingFilter).isTrue();
         }
 
         @Test
@@ -85,8 +87,11 @@ class RequestResponseLoggingFilterTest {
 
         @Test
         @DisplayName("로깅 필터 빈이 등록되지 않는다")
+        @SuppressWarnings("rawtypes")
         void filterBeanNotExists() {
-            assertThat(context.getBeansOfType(LoggingFilterConfig.class)).isEmpty();
+            boolean hasLoggingFilter = context.getBeansOfType(FilterRegistrationBean.class).values().stream()
+                    .anyMatch(bean -> bean.getFilter() instanceof RequestResponseLoggingFilter);
+            assertThat(hasLoggingFilter).isFalse();
         }
     }
 }


### PR DESCRIPTION
## Summary
- Codex CLI 코드 리뷰에서 발견된 2가지 이슈 수정
- MDC traceId 덮어쓰기 방지: 기존 값 보존 후 필터 종료 시 복원
- 테스트 검증 강화: `FilterRegistrationBean` 중 `RequestResponseLoggingFilter` 타입만 구체적으로 검증

## Test plan
- [x] 전체 테스트 통과 (`./gradlew test`)
- [x] DevProfileTest: 로깅 필터 빈 등록 검증
- [x] DefaultProfileTest: 로깅 필터 빈 미등록 검증

Closes #13

🤖 Generated with [Claude Code](https://claude.com/claude-code)