### PR TITLE
feat: Rate Limit 필터 + Idempotency 필터 구현

### DIFF
--- a/src/main/java/com/example/exception/playground/common/CachedBodyHttpServletRequest.java
+++ b/src/main/java/com/example/exception/playground/common/CachedBodyHttpServletRequest.java
@@ -1,0 +1,45 @@
+package com.example.exception.playground.common;
+
+import jakarta.servlet.ReadListener;
+import jakarta.servlet.ServletInputStream;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletRequestWrapper;
+
+import java.io.ByteArrayInputStream;
+import java.io.IOException;
+
+public class CachedBodyHttpServletRequest extends HttpServletRequestWrapper {
+
+    private final byte[] cachedBody;
+
+    public CachedBodyHttpServletRequest(HttpServletRequest request, byte[] body) {
+        super(request);
+        this.cachedBody = body;
+    }
+
+    @Override
+    public ServletInputStream getInputStream() {
+        ByteArrayInputStream bais = new ByteArrayInputStream(cachedBody);
+        return new ServletInputStream() {
+            @Override
+            public boolean isFinished() {
+                return bais.available() == 0;
+            }
+
+            @Override
+            public boolean isReady() {
+                return true;
+            }
+
+            @Override
+            public void setReadListener(ReadListener readListener) {
+                // no-op
+            }
+
+            @Override
+            public int read() {
+                return bais.read();
+            }
+        };
+    }
+}

--- a/src/main/java/com/example/exception/playground/common/ErrorCode.java
+++ b/src/main/java/com/example/exception/playground/common/ErrorCode.java
@@ -19,7 +19,15 @@ public enum ErrorCode {
 
     // Auth
     UNAUTHORIZED(HttpStatus.UNAUTHORIZED, "A001", "Authentication required"),
-    ACCESS_DENIED(HttpStatus.FORBIDDEN, "A002", "Access denied");
+    ACCESS_DENIED(HttpStatus.FORBIDDEN, "A002", "Access denied"),
+
+    // Rate Limit
+    RATE_LIMIT_EXCEEDED(HttpStatus.TOO_MANY_REQUESTS, "R001", "Too many requests"),
+
+    // Idempotency
+    IDEMPOTENCY_KEY_MISSING(HttpStatus.BAD_REQUEST, "I001", "Idempotency-Key header is required"),
+    IDEMPOTENCY_KEY_REUSED(HttpStatus.CONFLICT, "I002", "Request in progress with this key"),
+    IDEMPOTENCY_FINGERPRINT_MISMATCH(HttpStatus.UNPROCESSABLE_ENTITY, "I003", "Request does not match original");
 
     private final HttpStatus status;
     private final String code;

--- a/src/main/java/com/example/exception/playground/common/FilterErrorResponseWriter.java
+++ b/src/main/java/com/example/exception/playground/common/FilterErrorResponseWriter.java
@@ -1,0 +1,26 @@
+package com.example.exception.playground.common;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule;
+import jakarta.servlet.http.HttpServletResponse;
+import org.slf4j.MDC;
+import org.springframework.http.MediaType;
+
+import java.io.IOException;
+
+public final class FilterErrorResponseWriter {
+
+    private static final ObjectMapper OBJECT_MAPPER = new ObjectMapper()
+            .registerModule(new JavaTimeModule());
+
+    private FilterErrorResponseWriter() {
+    }
+
+    public static void write(HttpServletResponse response, ErrorCode errorCode, String message) throws IOException {
+        ErrorResponse errorResponse = ErrorResponse.of(errorCode, message);
+        response.setStatus(errorCode.getStatus().value());
+        response.setContentType(MediaType.APPLICATION_JSON_VALUE);
+        response.setCharacterEncoding("UTF-8");
+        response.getWriter().write(OBJECT_MAPPER.writeValueAsString(errorResponse));
+    }
+}

--- a/src/main/java/com/example/exception/playground/common/IdempotencyFilter.java
+++ b/src/main/java/com/example/exception/playground/common/IdempotencyFilter.java
@@ -1,0 +1,137 @@
+package com.example.exception.playground.common;
+
+import jakarta.servlet.FilterChain;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import org.springframework.web.filter.OncePerRequestFilter;
+import org.springframework.web.util.ContentCachingResponseWrapper;
+
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import java.security.MessageDigest;
+import java.security.NoSuchAlgorithmException;
+import java.util.HexFormat;
+import java.util.Set;
+import java.util.concurrent.ConcurrentHashMap;
+
+public class IdempotencyFilter extends OncePerRequestFilter {
+
+    private static final String IDEMPOTENCY_KEY_HEADER = "Idempotency-Key";
+    private static final Set<String> IDEMPOTENT_METHODS = Set.of("POST", "PUT", "PATCH");
+
+    private final long ttlMillis;
+    private final ConcurrentHashMap<String, IdempotencyEntry> cache = new ConcurrentHashMap<>();
+
+    public IdempotencyFilter(long ttlMillis) {
+        this.ttlMillis = ttlMillis;
+    }
+
+    @Override
+    protected void doFilterInternal(HttpServletRequest request, HttpServletResponse response,
+                                    FilterChain filterChain) throws ServletException, IOException {
+        if (!IDEMPOTENT_METHODS.contains(request.getMethod())) {
+            filterChain.doFilter(request, response);
+            return;
+        }
+
+        String idempotencyKey = request.getHeader(IDEMPOTENCY_KEY_HEADER);
+        if (idempotencyKey == null || idempotencyKey.isBlank()) {
+            FilterErrorResponseWriter.write(response, ErrorCode.IDEMPOTENCY_KEY_MISSING,
+                    "Idempotency-Key header is required for " + request.getMethod() + " requests");
+            return;
+        }
+
+        evictExpired();
+
+        // Read body for fingerprint (use CachedBodyHttpServletRequest)
+        byte[] body = request.getInputStream().readAllBytes();
+        String fingerprint = buildFingerprint(request.getMethod(), request.getRequestURI(), body);
+
+        // Try to claim this key atomically
+        IdempotencyEntry newEntry = IdempotencyEntry.inProgress(fingerprint);
+        IdempotencyEntry existing = cache.putIfAbsent(idempotencyKey, newEntry);
+
+        if (existing != null) {
+            if (existing.isExpired(System.currentTimeMillis(), ttlMillis)) {
+                // Expired entry - remove and retry
+                cache.remove(idempotencyKey, existing);
+                // Allow re-processing by falling through
+                cache.putIfAbsent(idempotencyKey, newEntry);
+            } else {
+                handleExistingEntry(existing, fingerprint, response);
+                return;
+            }
+        }
+
+        // Process the request with a wrapped request that replays the body
+        CachedBodyHttpServletRequest cachedRequest = new CachedBodyHttpServletRequest(request, body);
+        ContentCachingResponseWrapper wrappedResponse = new ContentCachingResponseWrapper(response);
+
+        try {
+            filterChain.doFilter(cachedRequest, wrappedResponse);
+        } finally {
+            wrappedResponse.copyBodyToResponse();
+        }
+
+        // Cache only 2xx responses
+        if (wrappedResponse.getStatus() >= 200 && wrappedResponse.getStatus() < 300) {
+            cache.put(idempotencyKey, IdempotencyEntry.completed(fingerprint, wrappedResponse.getStatus()));
+        } else {
+            cache.remove(idempotencyKey);
+        }
+    }
+
+    private void handleExistingEntry(IdempotencyEntry existing, String fingerprint,
+                                     HttpServletResponse response) throws IOException {
+        if (!existing.fingerprint().equals(fingerprint)) {
+            FilterErrorResponseWriter.write(response, ErrorCode.IDEMPOTENCY_FINGERPRINT_MISMATCH,
+                    "Request does not match the original request for this Idempotency-Key");
+            return;
+        }
+
+        if (existing.status() == IdempotencyStatus.IN_PROGRESS) {
+            FilterErrorResponseWriter.write(response, ErrorCode.IDEMPOTENCY_KEY_REUSED,
+                    "A request with this Idempotency-Key is already in progress");
+            return;
+        }
+
+        // Return cached response status
+        response.setStatus(existing.httpStatus());
+    }
+
+    private String buildFingerprint(String method, String uri, byte[] body) {
+        String raw = method + "|" + uri + "|" + new String(body, StandardCharsets.UTF_8);
+        try {
+            MessageDigest md = MessageDigest.getInstance("SHA-256");
+            byte[] hash = md.digest(raw.getBytes(StandardCharsets.UTF_8));
+            return HexFormat.of().formatHex(hash);
+        } catch (NoSuchAlgorithmException e) {
+            return raw;
+        }
+    }
+
+    private void evictExpired() {
+        long now = System.currentTimeMillis();
+        cache.values().removeIf(entry -> entry.isExpired(now, ttlMillis));
+    }
+
+    enum IdempotencyStatus {
+        IN_PROGRESS, COMPLETED
+    }
+
+    record IdempotencyEntry(String fingerprint, IdempotencyStatus status, int httpStatus, long createdAt) {
+
+        static IdempotencyEntry inProgress(String fingerprint) {
+            return new IdempotencyEntry(fingerprint, IdempotencyStatus.IN_PROGRESS, 0, System.currentTimeMillis());
+        }
+
+        static IdempotencyEntry completed(String fingerprint, int httpStatus) {
+            return new IdempotencyEntry(fingerprint, IdempotencyStatus.COMPLETED, httpStatus, System.currentTimeMillis());
+        }
+
+        boolean isExpired(long now, long ttlMillis) {
+            return now - createdAt > ttlMillis;
+        }
+    }
+}

--- a/src/main/java/com/example/exception/playground/common/LoggingFilterConfig.java
+++ b/src/main/java/com/example/exception/playground/common/LoggingFilterConfig.java
@@ -10,12 +10,34 @@ import org.springframework.core.Ordered;
 @Profile("dev")
 public class LoggingFilterConfig {
 
+    private static final int RATE_LIMIT_ORDER = Ordered.HIGHEST_PRECEDENCE;
+    private static final int IDEMPOTENCY_ORDER = Ordered.HIGHEST_PRECEDENCE + 1;
+    private static final int LOGGING_ORDER = Ordered.HIGHEST_PRECEDENCE + 2;
+
+    @Bean
+    public FilterRegistrationBean<RateLimitFilter> rateLimitFilter() {
+        FilterRegistrationBean<RateLimitFilter> registration = new FilterRegistrationBean<>();
+        registration.setFilter(new RateLimitFilter(10, 60_000));
+        registration.addUrlPatterns("/api/*");
+        registration.setOrder(RATE_LIMIT_ORDER);
+        return registration;
+    }
+
+    @Bean
+    public FilterRegistrationBean<IdempotencyFilter> idempotencyFilter() {
+        FilterRegistrationBean<IdempotencyFilter> registration = new FilterRegistrationBean<>();
+        registration.setFilter(new IdempotencyFilter(300_000));
+        registration.addUrlPatterns("/api/*");
+        registration.setOrder(IDEMPOTENCY_ORDER);
+        return registration;
+    }
+
     @Bean
     public FilterRegistrationBean<RequestResponseLoggingFilter> loggingFilter() {
         FilterRegistrationBean<RequestResponseLoggingFilter> registration = new FilterRegistrationBean<>();
         registration.setFilter(new RequestResponseLoggingFilter());
         registration.addUrlPatterns("/api/*");
-        registration.setOrder(Ordered.HIGHEST_PRECEDENCE);
+        registration.setOrder(LOGGING_ORDER);
         return registration;
     }
 }

--- a/src/main/java/com/example/exception/playground/common/RateLimitFilter.java
+++ b/src/main/java/com/example/exception/playground/common/RateLimitFilter.java
@@ -1,0 +1,69 @@
+package com.example.exception.playground.common;
+
+import jakarta.servlet.FilterChain;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import org.springframework.web.filter.OncePerRequestFilter;
+
+import java.io.IOException;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.atomic.AtomicInteger;
+
+public class RateLimitFilter extends OncePerRequestFilter {
+
+    private final int maxRequests;
+    private final long windowMillis;
+    private final ConcurrentHashMap<String, RateLimitBucket> buckets = new ConcurrentHashMap<>();
+
+    public RateLimitFilter(int maxRequests, long windowMillis) {
+        this.maxRequests = maxRequests;
+        this.windowMillis = windowMillis;
+    }
+
+    @Override
+    protected void doFilterInternal(HttpServletRequest request, HttpServletResponse response,
+                                    FilterChain filterChain) throws ServletException, IOException {
+        String clientIp = request.getRemoteAddr();
+        long now = System.currentTimeMillis();
+
+        RateLimitBucket bucket = buckets.compute(clientIp, (key, existing) -> {
+            if (existing == null || existing.isExpired(now)) {
+                return new RateLimitBucket(now, windowMillis);
+            }
+            return existing;
+        });
+
+        if (bucket.incrementAndCheck(maxRequests)) {
+            filterChain.doFilter(request, response);
+        } else {
+            long retryAfterSeconds = Math.max(1, (bucket.getResetTime() - now) / 1000);
+            response.setHeader("Retry-After", String.valueOf(retryAfterSeconds));
+            FilterErrorResponseWriter.write(response, ErrorCode.RATE_LIMIT_EXCEEDED,
+                    "Rate limit exceeded. Try again in " + retryAfterSeconds + " seconds");
+        }
+    }
+
+    static class RateLimitBucket {
+        private final long windowStart;
+        private final long windowMillis;
+        private final AtomicInteger count = new AtomicInteger(0);
+
+        RateLimitBucket(long windowStart, long windowMillis) {
+            this.windowStart = windowStart;
+            this.windowMillis = windowMillis;
+        }
+
+        boolean isExpired(long now) {
+            return now >= windowStart + windowMillis;
+        }
+
+        long getResetTime() {
+            return windowStart + windowMillis;
+        }
+
+        boolean incrementAndCheck(int maxRequests) {
+            return count.incrementAndGet() <= maxRequests;
+        }
+    }
+}

--- a/src/test/java/com/example/exception/playground/common/IdempotencyFilterTest.java
+++ b/src/test/java/com/example/exception/playground/common/IdempotencyFilterTest.java
@@ -1,0 +1,148 @@
+package com.example.exception.playground.common;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.web.servlet.FilterRegistrationBean;
+import org.springframework.context.ApplicationContext;
+import org.springframework.http.MediaType;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.web.servlet.MockMvc;
+
+import java.util.UUID;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+@DisplayName("IdempotencyFilter")
+class IdempotencyFilterTest {
+
+    @Nested
+    @DisplayName("dev 프로파일에서 Idempotency 필터 활성화")
+    @SpringBootTest
+    @AutoConfigureMockMvc
+    @ActiveProfiles("dev")
+    class DevProfileTest {
+
+        @Autowired
+        private MockMvc mockMvc;
+
+        @Autowired
+        private ApplicationContext context;
+
+        @Test
+        @DisplayName("Idempotency 필터 빈이 등록되어 있다")
+        @SuppressWarnings("rawtypes")
+        void filterBeanExists() {
+            boolean hasIdempotencyFilter = context.getBeansOfType(FilterRegistrationBean.class).values().stream()
+                    .anyMatch(bean -> bean.getFilter() instanceof IdempotencyFilter);
+            assertThat(hasIdempotencyFilter).isTrue();
+        }
+
+        @Test
+        @DisplayName("GET 요청에는 Idempotency-Key가 불필요")
+        void getRequestNoKeyRequired() throws Exception {
+            mockMvc.perform(get("/api/samples/1"))
+                    .andExpect(status().isOk());
+        }
+
+        @Test
+        @DisplayName("POST 요청 시 Idempotency-Key 헤더 없으면 400")
+        void postWithoutKey() throws Exception {
+            mockMvc.perform(post("/api/samples")
+                            .contentType(MediaType.APPLICATION_JSON)
+                            .content("""
+                                    {"name": "test", "age": 25}
+                                    """))
+                    .andExpect(status().isBadRequest())
+                    .andExpect(jsonPath("$.code").value("I001"));
+        }
+
+        @Test
+        @DisplayName("POST 요청 시 Idempotency-Key 포함하면 정상 처리")
+        void postWithKey() throws Exception {
+            String key = UUID.randomUUID().toString();
+            mockMvc.perform(post("/api/samples")
+                            .header("Idempotency-Key", key)
+                            .contentType(MediaType.APPLICATION_JSON)
+                            .content("""
+                                    {"name": "test", "age": 25}
+                                    """))
+                    .andExpect(status().isOk())
+                    .andExpect(jsonPath("$.result").value("created"));
+        }
+
+        @Test
+        @DisplayName("동일 키 + 동일 바디 재요청 시 캐싱된 응답 반환 (200)")
+        void duplicateRequestReturnsCached() throws Exception {
+            String key = UUID.randomUUID().toString();
+            String body = """
+                    {"name": "idempotent", "age": 30}
+                    """;
+
+            // First request
+            mockMvc.perform(post("/api/samples")
+                            .header("Idempotency-Key", key)
+                            .contentType(MediaType.APPLICATION_JSON)
+                            .content(body))
+                    .andExpect(status().isOk());
+
+            // Second request with same key + same body
+            mockMvc.perform(post("/api/samples")
+                            .header("Idempotency-Key", key)
+                            .contentType(MediaType.APPLICATION_JSON)
+                            .content(body))
+                    .andExpect(status().isOk());
+        }
+
+        @Test
+        @DisplayName("동일 키 + 다른 바디 시 422 응답")
+        void sameKeyDifferentBody() throws Exception {
+            String key = UUID.randomUUID().toString();
+
+            // First request
+            mockMvc.perform(post("/api/samples")
+                            .header("Idempotency-Key", key)
+                            .contentType(MediaType.APPLICATION_JSON)
+                            .content("""
+                                    {"name": "first", "age": 20}
+                                    """))
+                    .andExpect(status().isOk());
+
+            // Second request with same key but different body
+            mockMvc.perform(post("/api/samples")
+                            .header("Idempotency-Key", key)
+                            .contentType(MediaType.APPLICATION_JSON)
+                            .content("""
+                                    {"name": "second", "age": 30}
+                                    """))
+                    .andExpect(status().isUnprocessableEntity())
+                    .andExpect(jsonPath("$.code").value("I003"));
+        }
+    }
+
+    @Nested
+    @DisplayName("기본 프로파일에서 Idempotency 필터 비활성화")
+    @SpringBootTest
+    @AutoConfigureMockMvc
+    class DefaultProfileTest {
+
+        @Autowired
+        private ApplicationContext context;
+
+        @Test
+        @DisplayName("Idempotency 필터 빈이 등록되지 않는다")
+        @SuppressWarnings("rawtypes")
+        void filterBeanNotExists() {
+            boolean hasIdempotencyFilter = context.getBeansOfType(FilterRegistrationBean.class).values().stream()
+                    .anyMatch(bean -> bean.getFilter() instanceof IdempotencyFilter);
+            assertThat(hasIdempotencyFilter).isFalse();
+        }
+    }
+}

--- a/src/test/java/com/example/exception/playground/common/RateLimitFilterTest.java
+++ b/src/test/java/com/example/exception/playground/common/RateLimitFilterTest.java
@@ -1,0 +1,93 @@
+package com.example.exception.playground.common;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.MethodOrderer;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Order;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.TestMethodOrder;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.web.servlet.FilterRegistrationBean;
+import org.springframework.context.ApplicationContext;
+import org.springframework.test.annotation.DirtiesContext;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.web.servlet.MockMvc;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
+
+@DisplayName("RateLimitFilter")
+class RateLimitFilterTest {
+
+    @Nested
+    @DisplayName("dev 프로파일에서 Rate Limit 필터 활성화")
+    @SpringBootTest
+    @AutoConfigureMockMvc
+    @ActiveProfiles("dev")
+    @DirtiesContext
+    @TestMethodOrder(MethodOrderer.OrderAnnotation.class)
+    class DevProfileTest {
+
+        @Autowired
+        private MockMvc mockMvc;
+
+        @Autowired
+        private ApplicationContext context;
+
+        @Test
+        @Order(1)
+        @DisplayName("Rate Limit 필터 빈이 등록되어 있다")
+        @SuppressWarnings("rawtypes")
+        void filterBeanExists() {
+            boolean hasRateLimitFilter = context.getBeansOfType(FilterRegistrationBean.class).values().stream()
+                    .anyMatch(bean -> bean.getFilter() instanceof RateLimitFilter);
+            assertThat(hasRateLimitFilter).isTrue();
+        }
+
+        @Test
+        @Order(2)
+        @DisplayName("제한 내 요청은 정상 응답")
+        void withinLimit() throws Exception {
+            mockMvc.perform(get("/api/samples/1"))
+                    .andExpect(status().isOk());
+        }
+
+        @Test
+        @Order(3)
+        @DisplayName("제한 초과 시 429 응답 + Retry-After 헤더")
+        void exceedsLimit() throws Exception {
+            // 남은 quota를 모두 소진 (이전 테스트에서 사용된 횟수에 관계없이)
+            for (int i = 0; i < 20; i++) {
+                mockMvc.perform(get("/api/samples/1"));
+            }
+
+            // 확실히 초과된 상태에서 429 확인
+            mockMvc.perform(get("/api/samples/1"))
+                    .andExpect(status().isTooManyRequests())
+                    .andExpect(jsonPath("$.code").value("R001"))
+                    .andExpect(header().exists("Retry-After"));
+        }
+    }
+
+    @Nested
+    @DisplayName("기본 프로파일에서 Rate Limit 필터 비활성화")
+    @SpringBootTest
+    @AutoConfigureMockMvc
+    class DefaultProfileTest {
+
+        @Autowired
+        private ApplicationContext context;
+
+        @Test
+        @DisplayName("Rate Limit 필터 빈이 등록되지 않는다")
+        @SuppressWarnings("rawtypes")
+        void filterBeanNotExists() {
+            boolean hasRateLimitFilter = context.getBeansOfType(FilterRegistrationBean.class).values().stream()
+                    .anyMatch(bean -> bean.getFilter() instanceof RateLimitFilter);
+            assertThat(hasRateLimitFilter).isFalse();
+        }
+    }
+}

--- a/src/test/java/com/example/exception/playground/common/RequestResponseLoggingFilterTest.java
+++ b/src/test/java/com/example/exception/playground/common/RequestResponseLoggingFilterTest.java
@@ -12,6 +12,8 @@ import org.springframework.http.MediaType;
 import org.springframework.test.context.ActiveProfiles;
 import org.springframework.test.web.servlet.MockMvc;
 
+import java.util.UUID;
+
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
@@ -67,6 +69,7 @@ class RequestResponseLoggingFilterTest {
         @DisplayName("POST 요청 바디도 로깅")
         void postRequestBodyLogged() throws Exception {
             mockMvc.perform(post("/api/samples")
+                            .header("Idempotency-Key", UUID.randomUUID().toString())
                             .contentType(MediaType.APPLICATION_JSON)
                             .content("""
                                     {"name": "test", "age": 25}


### PR DESCRIPTION
## Summary
- Rate Limit 필터: IP 기반 고정 윈도우 (10req/60s), 429 + Retry-After 헤더
- Idempotency 필터: Idempotency-Key 헤더 기반 멱등성 보장
  - fingerprint (method + path + body hash)로 요청 식별
  - 2xx만 캐시, 동시성 상태 모델 (IN_PROGRESS/COMPLETED)
- 필터 순서: Rate Limit → Idempotency → Logging
- ErrorCode 4개 확장 (R001, I001, I002, I003)
- 필터 예외는 ControllerAdvice 밖이므로 직접 JSON 응답 작성
- Codex CLI 피드백 반영: fingerprint 검증, 캐시 정책, 동시성 모델, 필터 순서 명시

## Test plan
- [x] 전체 테스트 통과 (34개)
- [x] Rate Limit: 제한 내 200, 초과 시 429 + Retry-After
- [x] Idempotency: 키 없으면 400, 동일 키 재요청 200, 다른 바디 422
- [x] GET 요청은 키 불필요
- [x] 기본 프로파일에서 모든 필터 비활성화

Closes #15

🤖 Generated with [Claude Code](https://claude.com/claude-code)