### PR TITLE
refactor: 헥사고날 아키텍처 기반 패키지 구조 재편

### DIFF
--- a/src/main/java/com/example/exception/playground/global/error/ErrorCode.java
+++ b/src/main/java/com/example/exception/playground/global/error/ErrorCode.java
@@ -1,4 +1,4 @@
-package com.example.exception.playground.common;
+package com.example.exception.playground.global.error;
 
 import org.springframework.http.HttpStatus;
 

--- a/src/main/java/com/example/exception/playground/global/error/ErrorResponse.java
+++ b/src/main/java/com/example/exception/playground/global/error/ErrorResponse.java
@@ -1,4 +1,4 @@
-package com.example.exception.playground.common;
+package com.example.exception.playground.global.error;
 
 import com.fasterxml.jackson.annotation.JsonInclude;
 

--- a/src/main/java/com/example/exception/playground/global/exception/AccessDeniedException.java
+++ b/src/main/java/com/example/exception/playground/global/exception/AccessDeniedException.java
@@ -1,4 +1,6 @@
-package com.example.exception.playground.common;
+package com.example.exception.playground.global.exception;
+
+import com.example.exception.playground.global.error.ErrorCode;
 
 public class AccessDeniedException extends BusinessException {
 

--- a/src/main/java/com/example/exception/playground/global/exception/BusinessException.java
+++ b/src/main/java/com/example/exception/playground/global/exception/BusinessException.java
@@ -1,4 +1,6 @@
-package com.example.exception.playground.common;
+package com.example.exception.playground.global.exception;
+
+import com.example.exception.playground.global.error.ErrorCode;
 
 public class BusinessException extends RuntimeException {
 

--- a/src/main/java/com/example/exception/playground/global/exception/BusinessRuleViolationException.java
+++ b/src/main/java/com/example/exception/playground/global/exception/BusinessRuleViolationException.java
@@ -1,4 +1,6 @@
-package com.example.exception.playground.common;
+package com.example.exception.playground.global.exception;
+
+import com.example.exception.playground.global.error.ErrorCode;
 
 public class BusinessRuleViolationException extends BusinessException {
 

--- a/src/main/java/com/example/exception/playground/global/exception/DuplicateResourceException.java
+++ b/src/main/java/com/example/exception/playground/global/exception/DuplicateResourceException.java
@@ -1,4 +1,6 @@
-package com.example.exception.playground.common;
+package com.example.exception.playground.global.exception;
+
+import com.example.exception.playground.global.error.ErrorCode;
 
 public class DuplicateResourceException extends BusinessException {
 

--- a/src/main/java/com/example/exception/playground/global/exception/NotFoundException.java
+++ b/src/main/java/com/example/exception/playground/global/exception/NotFoundException.java
@@ -1,4 +1,6 @@
-package com.example.exception.playground.common;
+package com.example.exception.playground.global.exception;
+
+import com.example.exception.playground.global.error.ErrorCode;
 
 public class NotFoundException extends BusinessException {
 

--- a/src/main/java/com/example/exception/playground/global/exception/UnauthorizedException.java
+++ b/src/main/java/com/example/exception/playground/global/exception/UnauthorizedException.java
@@ -1,4 +1,6 @@
-package com.example.exception.playground.common;
+package com.example.exception.playground.global.exception;
+
+import com.example.exception.playground.global.error.ErrorCode;
 
 public class UnauthorizedException extends BusinessException {
 

--- a/src/main/java/com/example/exception/playground/global/filter/CachedBodyHttpServletRequest.java
+++ b/src/main/java/com/example/exception/playground/global/filter/CachedBodyHttpServletRequest.java
@@ -1,4 +1,4 @@
-package com.example.exception.playground.common;
+package com.example.exception.playground.global.filter;
 
 import jakarta.servlet.ReadListener;
 import jakarta.servlet.ServletInputStream;

--- a/src/main/java/com/example/exception/playground/global/filter/FilterConfig.java
+++ b/src/main/java/com/example/exception/playground/global/filter/FilterConfig.java
@@ -1,4 +1,4 @@
-package com.example.exception.playground.common;
+package com.example.exception.playground.global.filter;
 
 import org.springframework.boot.web.servlet.FilterRegistrationBean;
 import org.springframework.context.annotation.Bean;
@@ -8,7 +8,7 @@ import org.springframework.core.Ordered;
 
 @Configuration
 @Profile("dev")
-public class LoggingFilterConfig {
+public class FilterConfig {
 
     private static final int RATE_LIMIT_ORDER = Ordered.HIGHEST_PRECEDENCE;
     private static final int IDEMPOTENCY_ORDER = Ordered.HIGHEST_PRECEDENCE + 1;

--- a/src/main/java/com/example/exception/playground/global/filter/FilterErrorResponseWriter.java
+++ b/src/main/java/com/example/exception/playground/global/filter/FilterErrorResponseWriter.java
@@ -1,6 +1,10 @@
-package com.example.exception.playground.common;
+package com.example.exception.playground.global.filter;
 
+import com.example.exception.playground.global.error.ErrorCode;
+import com.example.exception.playground.global.error.ErrorResponse;
 import com.fasterxml.jackson.databind.ObjectMapper;
+import com.example.exception.playground.global.error.ErrorCode;
+import com.example.exception.playground.global.error.ErrorResponse;
 import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule;
 import jakarta.servlet.http.HttpServletResponse;
 import org.slf4j.MDC;

--- a/src/main/java/com/example/exception/playground/global/filter/IdempotencyFilter.java
+++ b/src/main/java/com/example/exception/playground/global/filter/IdempotencyFilter.java
@@ -1,8 +1,12 @@
-package com.example.exception.playground.common;
+package com.example.exception.playground.global.filter;
 
+import com.example.exception.playground.global.error.ErrorCode;
 import jakarta.servlet.FilterChain;
+import com.example.exception.playground.global.error.ErrorCode;
 import jakarta.servlet.ServletException;
+import com.example.exception.playground.global.error.ErrorCode;
 import jakarta.servlet.http.HttpServletRequest;
+import com.example.exception.playground.global.error.ErrorCode;
 import jakarta.servlet.http.HttpServletResponse;
 import org.springframework.web.filter.OncePerRequestFilter;
 import org.springframework.web.util.ContentCachingResponseWrapper;

--- a/src/main/java/com/example/exception/playground/global/filter/RateLimitFilter.java
+++ b/src/main/java/com/example/exception/playground/global/filter/RateLimitFilter.java
@@ -1,8 +1,12 @@
-package com.example.exception.playground.common;
+package com.example.exception.playground.global.filter;
 
+import com.example.exception.playground.global.error.ErrorCode;
 import jakarta.servlet.FilterChain;
+import com.example.exception.playground.global.error.ErrorCode;
 import jakarta.servlet.ServletException;
+import com.example.exception.playground.global.error.ErrorCode;
 import jakarta.servlet.http.HttpServletRequest;
+import com.example.exception.playground.global.error.ErrorCode;
 import jakarta.servlet.http.HttpServletResponse;
 import org.springframework.web.filter.OncePerRequestFilter;
 

--- a/src/main/java/com/example/exception/playground/global/filter/RequestResponseLoggingFilter.java
+++ b/src/main/java/com/example/exception/playground/global/filter/RequestResponseLoggingFilter.java
@@ -1,4 +1,4 @@
-package com.example.exception.playground.common;
+package com.example.exception.playground.global.filter;
 
 import jakarta.servlet.FilterChain;
 import jakarta.servlet.ServletException;

--- a/src/main/java/com/example/exception/playground/global/handler/GlobalExceptionHandler.java
+++ b/src/main/java/com/example/exception/playground/global/handler/GlobalExceptionHandler.java
@@ -1,5 +1,8 @@
-package com.example.exception.playground.common;
+package com.example.exception.playground.global.handler;
 
+import com.example.exception.playground.global.error.ErrorCode;
+import com.example.exception.playground.global.error.ErrorResponse;
+import com.example.exception.playground.global.exception.BusinessException;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Value;

--- a/src/main/java/com/example/exception/playground/sample/adapter/in/web/SampleController.java
+++ b/src/main/java/com/example/exception/playground/sample/adapter/in/web/SampleController.java
@@ -1,10 +1,10 @@
-package com.example.exception.playground.sample;
+package com.example.exception.playground.sample.adapter.in.web;
 
-import com.example.exception.playground.common.AccessDeniedException;
-import com.example.exception.playground.common.BusinessRuleViolationException;
-import com.example.exception.playground.common.DuplicateResourceException;
-import com.example.exception.playground.common.NotFoundException;
-import com.example.exception.playground.common.UnauthorizedException;
+import com.example.exception.playground.global.exception.AccessDeniedException;
+import com.example.exception.playground.global.exception.BusinessRuleViolationException;
+import com.example.exception.playground.global.exception.DuplicateResourceException;
+import com.example.exception.playground.global.exception.NotFoundException;
+import com.example.exception.playground.global.exception.UnauthorizedException;
 import jakarta.validation.Valid;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;

--- a/src/main/java/com/example/exception/playground/sample/adapter/in/web/SampleRequest.java
+++ b/src/main/java/com/example/exception/playground/sample/adapter/in/web/SampleRequest.java
@@ -1,4 +1,4 @@
-package com.example.exception.playground.sample;
+package com.example.exception.playground.sample.adapter.in.web;
 
 import jakarta.validation.constraints.Min;
 import jakarta.validation.constraints.NotBlank;

--- a/src/test/java/com/example/exception/playground/global/filter/IdempotencyFilterTest.java
+++ b/src/test/java/com/example/exception/playground/global/filter/IdempotencyFilterTest.java
@@ -1,4 +1,4 @@
-package com.example.exception.playground.common;
+package com.example.exception.playground.global.filter;
 
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;

--- a/src/test/java/com/example/exception/playground/global/filter/RateLimitFilterTest.java
+++ b/src/test/java/com/example/exception/playground/global/filter/RateLimitFilterTest.java
@@ -1,4 +1,4 @@
-package com.example.exception.playground.common;
+package com.example.exception.playground.global.filter;
 
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.MethodOrderer;

--- a/src/test/java/com/example/exception/playground/global/filter/RequestResponseLoggingFilterTest.java
+++ b/src/test/java/com/example/exception/playground/global/filter/RequestResponseLoggingFilterTest.java
@@ -1,4 +1,4 @@
-package com.example.exception.playground.common;
+package com.example.exception.playground.global.filter;
 
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;

--- a/src/test/java/com/example/exception/playground/global/handler/GlobalExceptionHandlerDebugTest.java
+++ b/src/test/java/com/example/exception/playground/global/handler/GlobalExceptionHandlerDebugTest.java
@@ -1,6 +1,6 @@
-package com.example.exception.playground.common;
+package com.example.exception.playground.global.handler;
 
-import com.example.exception.playground.sample.SampleController;
+import com.example.exception.playground.sample.adapter.in.web.SampleController;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;

--- a/src/test/java/com/example/exception/playground/global/handler/GlobalExceptionHandlerIntegrationTest.java
+++ b/src/test/java/com/example/exception/playground/global/handler/GlobalExceptionHandlerIntegrationTest.java
@@ -1,4 +1,4 @@
-package com.example.exception.playground.common;
+package com.example.exception.playground.global.handler;
 
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;

--- a/src/test/java/com/example/exception/playground/global/handler/GlobalExceptionHandlerTest.java
+++ b/src/test/java/com/example/exception/playground/global/handler/GlobalExceptionHandlerTest.java
@@ -1,6 +1,6 @@
-package com.example.exception.playground.common;
+package com.example.exception.playground.global.handler;
 
-import com.example.exception.playground.sample.SampleController;
+import com.example.exception.playground.sample.adapter.in.web.SampleController;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;


### PR DESCRIPTION
## Summary
- flat 구조(common/, sample/)를 헥사고날 아키텍처 기반으로 재편
- `global/error/` - 에러 모델 (ErrorCode, ErrorResponse)
- `global/exception/` - 도메인 예외 계층 (BusinessException 등)
- `global/handler/` - 예외 처리 어댑터 (GlobalExceptionHandler)
- `global/filter/` - HTTP 필터 어댑터 (RateLimit, Idempotency, Logging)
- `sample/adapter/in/web/` - 인바운드 웹 어댑터 (SampleController)
- LoggingFilterConfig → FilterConfig 이름 변경
- 기능 변경 없음, 순수 리팩토링

## Test plan
- [x] 전체 테스트 통과 (34개)
- [x] Git rename 히스토리 보존 확인

Closes #17

🤖 Generated with [Claude Code](https://claude.com/claude-code)