### PR TITLE
refactor: 필터 실행 순서 변경 및 IdempotencyFilter 응답 본문 캐싱

### DIFF
--- a/src/main/java/com/example/exception/playground/global/filter/FilterConfig.java
+++ b/src/main/java/com/example/exception/playground/global/filter/FilterConfig.java
@@ -12,9 +12,9 @@ import org.springframework.core.Ordered;
 @EnableConfigurationProperties(FilterProperties.class)
 public class FilterConfig {
 
-    private static final int RATE_LIMIT_ORDER = Ordered.HIGHEST_PRECEDENCE;
-    private static final int IDEMPOTENCY_ORDER = Ordered.HIGHEST_PRECEDENCE + 1;
-    private static final int LOGGING_ORDER = Ordered.HIGHEST_PRECEDENCE + 2;
+    private static final int LOGGING_ORDER = Ordered.HIGHEST_PRECEDENCE;
+    private static final int RATE_LIMIT_ORDER = Ordered.HIGHEST_PRECEDENCE + 1;
+    private static final int IDEMPOTENCY_ORDER = Ordered.HIGHEST_PRECEDENCE + 2;
 
     @Bean
     public FilterRegistrationBean<RateLimitFilter> rateLimitFilter(FilterProperties properties) {

--- a/src/main/java/com/example/exception/playground/global/filter/IdempotencyFilter.java
+++ b/src/main/java/com/example/exception/playground/global/filter/IdempotencyFilter.java
@@ -72,14 +72,16 @@ public class IdempotencyFilter extends OncePerRequestFilter {
         try {
             filterChain.doFilter(cachedRequest, wrappedResponse);
         } finally {
+            // Cache only 2xx responses (before copying body to response)
+            int status = wrappedResponse.getStatus();
+            if (status >= 200 && status < 300) {
+                String responseBody = new String(wrappedResponse.getContentAsByteArray(), StandardCharsets.UTF_8);
+                cache.put(idempotencyKey, IdempotencyEntry.completed(
+                        fingerprint, status, responseBody, wrappedResponse.getContentType()));
+            } else {
+                cache.remove(idempotencyKey);
+            }
             wrappedResponse.copyBodyToResponse();
-        }
-
-        // Cache only 2xx responses
-        if (wrappedResponse.getStatus() >= 200 && wrappedResponse.getStatus() < 300) {
-            cache.put(idempotencyKey, IdempotencyEntry.completed(fingerprint, wrappedResponse.getStatus()));
-        } else {
-            cache.remove(idempotencyKey);
         }
     }
 
@@ -97,8 +99,12 @@ public class IdempotencyFilter extends OncePerRequestFilter {
             return;
         }
 
-        // Return cached response status
+        // Return cached response
         response.setStatus(existing.httpStatus());
+        if (existing.responseBody() != null && !existing.responseBody().isBlank()) {
+            response.setContentType(existing.contentType());
+            response.getWriter().write(existing.responseBody());
+        }
     }
 
     private String buildFingerprint(String method, String uri, byte[] body) {
@@ -121,14 +127,18 @@ public class IdempotencyFilter extends OncePerRequestFilter {
         IN_PROGRESS, COMPLETED
     }
 
-    record IdempotencyEntry(String fingerprint, IdempotencyStatus status, int httpStatus, long createdAt) {
+    record IdempotencyEntry(String fingerprint, IdempotencyStatus status, int httpStatus, String responseBody,
+                            String contentType, long createdAt) {
 
         static IdempotencyEntry inProgress(String fingerprint) {
-            return new IdempotencyEntry(fingerprint, IdempotencyStatus.IN_PROGRESS, 0, System.currentTimeMillis());
+            return new IdempotencyEntry(fingerprint, IdempotencyStatus.IN_PROGRESS, 0, null, null,
+                    System.currentTimeMillis());
         }
 
-        static IdempotencyEntry completed(String fingerprint, int httpStatus) {
-            return new IdempotencyEntry(fingerprint, IdempotencyStatus.COMPLETED, httpStatus, System.currentTimeMillis());
+        static IdempotencyEntry completed(String fingerprint, int httpStatus, String responseBody,
+                                          String contentType) {
+            return new IdempotencyEntry(fingerprint, IdempotencyStatus.COMPLETED, httpStatus, responseBody,
+                    contentType, System.currentTimeMillis());
         }
 
         boolean isExpired(long now, long ttlMillis) {

--- a/src/main/java/com/example/exception/playground/global/filter/RequestResponseLoggingFilter.java
+++ b/src/main/java/com/example/exception/playground/global/filter/RequestResponseLoggingFilter.java
@@ -68,12 +68,14 @@ public class RequestResponseLoggingFilter extends OncePerRequestFilter {
             log.info("[{}] >>> Request Body: {}", traceId, requestBody);
         }
 
+        String responseLog = String.format("[%s] <<< %s %s | Status: %d | %dms%s",
+                traceId, request.getMethod(), request.getRequestURI(), status, duration,
+                body.isBlank() ? "" : " | Body: " + body);
+
         if (status >= 400) {
-            log.warn("[{}] <<< {} {} | Status: {} | {}ms | Body: {}",
-                    traceId, request.getMethod(), request.getRequestURI(), status, duration, body);
+            log.warn(responseLog);
         } else {
-            log.info("[{}] <<< {} {} | Status: {} | {}ms",
-                    traceId, request.getMethod(), request.getRequestURI(), status, duration);
+            log.info(responseLog);
         }
     }
 }

--- a/src/test/java/com/example/exception/playground/global/filter/RetryAndIdempotencyIntegrationTest.java
+++ b/src/test/java/com/example/exception/playground/global/filter/RetryAndIdempotencyIntegrationTest.java
@@ -165,7 +165,7 @@ class RetryAndIdempotencyIntegrationTest {
         private ApplicationContext context;
 
         @Test
-        @DisplayName("Rate Limit → Idempotency → Logging 순서로 등록")
+        @DisplayName("Logging → Rate Limit → Idempotency 순서로 등록")
         @SuppressWarnings("rawtypes")
         void filterOrderIsCorrect() {
             List<FilterRegistrationBean> filters = context.getBeansOfType(FilterRegistrationBean.class)
@@ -177,9 +177,9 @@ class RetryAndIdempotencyIntegrationTest {
                     .toList();
 
             assertThat(filters).hasSize(3);
-            assertThat(filters.get(0).getFilter()).isInstanceOf(RateLimitFilter.class);
-            assertThat(filters.get(1).getFilter()).isInstanceOf(IdempotencyFilter.class);
-            assertThat(filters.get(2).getFilter()).isInstanceOf(RequestResponseLoggingFilter.class);
+            assertThat(filters.get(0).getFilter()).isInstanceOf(RequestResponseLoggingFilter.class);
+            assertThat(filters.get(1).getFilter()).isInstanceOf(RateLimitFilter.class);
+            assertThat(filters.get(2).getFilter()).isInstanceOf(IdempotencyFilter.class);
         }
     }
 


### PR DESCRIPTION
## Summary
- 필터 실행 순서를 `Logging → RateLimit → Idempotency`로 변경하여 모든 요청/응답 로깅 보장
- IdempotencyFilter에서 응답 본문과 Content-Type을 함께 캐싱하여 중복 요청 시 완전한 응답 반환
- RequestResponseLoggingFilter 로그 포맷 통합 (성공/에러 동일 포맷)

## Changes
### 필터 순서 변경 (`FilterConfig`)
| Before | After |
|--------|-------|
| RateLimit (HIGHEST) | Logging (HIGHEST) |
| Idempotency (HIGHEST+1) | RateLimit (HIGHEST+1) |
| Logging (HIGHEST+2) | Idempotency (HIGHEST+2) |

### IdempotencyFilter 응답 본문 캐싱
- `IdempotencyEntry` record에 `responseBody`, `contentType` 필드 추가
- `copyBodyToResponse()` 호출 전에 캐싱하여 본문 유실 방지
- 캐싱된 본문을 중복 요청 시 반환

### RequestResponseLoggingFilter 로그 포맷 통합
- 성공/에러 응답 모두 동일한 포맷 사용
- 본문이 있으면 성공 응답에도 Body 표시

## Test plan
- [x] 기존 테스트 전체 통과 확인
- [x] 필터 순서 테스트 수정 및 통과

Closes #26

🤖 Generated with [Claude Code](https://claude.com/claude-code)