### PR TITLE
feat: 중계서비스 HTTP Status 기반 Gateway/처리상태 오류 코드 추가

### DIFF
--- a/src/main/java/com/example/exception/playground/global/error/ErrorCode.java
+++ b/src/main/java/com/example/exception/playground/global/error/ErrorCode.java
@@ -27,7 +27,15 @@ public enum ErrorCode {
     // Idempotency
     IDEMPOTENCY_KEY_MISSING(HttpStatus.BAD_REQUEST, "I001", "Idempotency-Key header is required"),
     IDEMPOTENCY_KEY_REUSED(HttpStatus.CONFLICT, "I002", "Request in progress with this key"),
-    IDEMPOTENCY_FINGERPRINT_MISMATCH(HttpStatus.UNPROCESSABLE_ENTITY, "I003", "Request does not match original");
+    IDEMPOTENCY_FINGERPRINT_MISMATCH(HttpStatus.UNPROCESSABLE_ENTITY, "I003", "Request does not match original"),
+
+    // Gateway (하위 서비스 통신 오류)
+    GATEWAY_ERROR(HttpStatus.BAD_GATEWAY, "G001", "Downstream service unavailable"),
+    GATEWAY_TIMEOUT(HttpStatus.GATEWAY_TIMEOUT, "G002", "Downstream service timeout"),
+    SERVICE_UNAVAILABLE(HttpStatus.SERVICE_UNAVAILABLE, "G003", "Service temporarily unavailable"),
+
+    // Accepted (비동기 처리 상태)
+    REQUEST_IN_PROGRESS(HttpStatus.ACCEPTED, "P001", "Request is being processed");
 
     private final HttpStatus status;
     private final String code;

--- a/src/main/java/com/example/exception/playground/global/error/ErrorResponse.java
+++ b/src/main/java/com/example/exception/playground/global/error/ErrorResponse.java
@@ -15,55 +15,73 @@ public class ErrorResponse {
     private final int status;
     private final LocalDateTime timestamp;
     private final List<FieldError> errors;
+    private final Boolean retryable;
+    private final String retryStrategy;
     private final String debugMessage;
     private final String stackTrace;
 
     private ErrorResponse(String code, String message, int status,
-                          List<FieldError> errors, String debugMessage, String stackTrace) {
+                          List<FieldError> errors, Boolean retryable, String retryStrategy,
+                          String debugMessage, String stackTrace) {
         this.traceId = UUID.randomUUID().toString().substring(0, 8);
         this.code = code;
         this.message = message;
         this.status = status;
         this.timestamp = LocalDateTime.now();
         this.errors = errors;
+        this.retryable = retryable;
+        this.retryStrategy = retryStrategy;
         this.debugMessage = debugMessage;
         this.stackTrace = stackTrace;
     }
 
     public static ErrorResponse of(ErrorCode errorCode) {
         return new ErrorResponse(errorCode.getCode(), errorCode.getMessage(),
-                errorCode.getStatus().value(), List.of(), null, null);
+                errorCode.getStatus().value(), List.of(), null, null, null, null);
     }
 
     public static ErrorResponse of(ErrorCode errorCode, String message) {
         return new ErrorResponse(errorCode.getCode(), message,
-                errorCode.getStatus().value(), List.of(), null, null);
+                errorCode.getStatus().value(), List.of(), null, null, null, null);
     }
 
     public static ErrorResponse of(ErrorCode errorCode, List<FieldError> errors) {
         return new ErrorResponse(errorCode.getCode(), errorCode.getMessage(),
-                errorCode.getStatus().value(), errors, null, null);
+                errorCode.getStatus().value(), errors, null, null, null, null);
+    }
+
+    public static ErrorResponse retryable(ErrorCode errorCode, String message, String retryStrategy) {
+        return new ErrorResponse(errorCode.getCode(), message,
+                errorCode.getStatus().value(), List.of(), true, retryStrategy, null, null);
     }
 
     public static ErrorResponse withDebug(ErrorCode errorCode, Exception e) {
         String debugMsg = e.getClass().getSimpleName() + ": " + e.getMessage();
         String trace = getStackTraceAsString(e);
         return new ErrorResponse(errorCode.getCode(), errorCode.getMessage(),
-                errorCode.getStatus().value(), List.of(), debugMsg, trace);
+                errorCode.getStatus().value(), List.of(), null, null, debugMsg, trace);
     }
 
     public static ErrorResponse withDebug(ErrorCode errorCode, String message, Exception e) {
         String debugMsg = e.getClass().getSimpleName() + ": " + e.getMessage();
         String trace = getStackTraceAsString(e);
         return new ErrorResponse(errorCode.getCode(), message,
-                errorCode.getStatus().value(), List.of(), debugMsg, trace);
+                errorCode.getStatus().value(), List.of(), null, null, debugMsg, trace);
     }
 
     public static ErrorResponse withDebug(ErrorCode errorCode, List<FieldError> errors, Exception e) {
         String debugMsg = e.getClass().getSimpleName() + ": " + e.getMessage();
         String trace = getStackTraceAsString(e);
         return new ErrorResponse(errorCode.getCode(), errorCode.getMessage(),
-                errorCode.getStatus().value(), errors, debugMsg, trace);
+                errorCode.getStatus().value(), errors, null, null, debugMsg, trace);
+    }
+
+    public static ErrorResponse retryableWithDebug(ErrorCode errorCode, String message,
+                                                    String retryStrategy, Exception e) {
+        String debugMsg = e.getClass().getSimpleName() + ": " + e.getMessage();
+        String trace = getStackTraceAsString(e);
+        return new ErrorResponse(errorCode.getCode(), message,
+                errorCode.getStatus().value(), List.of(), true, retryStrategy, debugMsg, trace);
     }
 
     private static String getStackTraceAsString(Exception e) {
@@ -100,6 +118,14 @@ public class ErrorResponse {
 
     public List<FieldError> getErrors() {
         return errors;
+    }
+
+    public Boolean getRetryable() {
+        return retryable;
+    }
+
+    public String getRetryStrategy() {
+        return retryStrategy;
     }
 
     public String getDebugMessage() {

--- a/src/main/java/com/example/exception/playground/global/exception/GatewayErrorException.java
+++ b/src/main/java/com/example/exception/playground/global/exception/GatewayErrorException.java
@@ -1,0 +1,14 @@
+package com.example.exception.playground.global.exception;
+
+import com.example.exception.playground.global.error.ErrorCode;
+
+public class GatewayErrorException extends GatewayException {
+
+    public GatewayErrorException(String message) {
+        super(ErrorCode.GATEWAY_ERROR, message);
+    }
+
+    public GatewayErrorException(String message, Throwable cause) {
+        super(ErrorCode.GATEWAY_ERROR, message, cause);
+    }
+}

--- a/src/main/java/com/example/exception/playground/global/exception/GatewayException.java
+++ b/src/main/java/com/example/exception/playground/global/exception/GatewayException.java
@@ -1,0 +1,27 @@
+package com.example.exception.playground.global.exception;
+
+import com.example.exception.playground.global.error.ErrorCode;
+
+public class GatewayException extends RuntimeException {
+
+    private final ErrorCode errorCode;
+
+    public GatewayException(ErrorCode errorCode) {
+        super(errorCode.getMessage());
+        this.errorCode = errorCode;
+    }
+
+    public GatewayException(ErrorCode errorCode, String message) {
+        super(message);
+        this.errorCode = errorCode;
+    }
+
+    public GatewayException(ErrorCode errorCode, String message, Throwable cause) {
+        super(message, cause);
+        this.errorCode = errorCode;
+    }
+
+    public ErrorCode getErrorCode() {
+        return errorCode;
+    }
+}

--- a/src/main/java/com/example/exception/playground/global/exception/GatewayTimeoutException.java
+++ b/src/main/java/com/example/exception/playground/global/exception/GatewayTimeoutException.java
@@ -1,0 +1,14 @@
+package com.example.exception.playground.global.exception;
+
+import com.example.exception.playground.global.error.ErrorCode;
+
+public class GatewayTimeoutException extends GatewayException {
+
+    public GatewayTimeoutException(String message) {
+        super(ErrorCode.GATEWAY_TIMEOUT, message);
+    }
+
+    public GatewayTimeoutException(String message, Throwable cause) {
+        super(ErrorCode.GATEWAY_TIMEOUT, message, cause);
+    }
+}

--- a/src/main/java/com/example/exception/playground/global/exception/RequestInProgressException.java
+++ b/src/main/java/com/example/exception/playground/global/exception/RequestInProgressException.java
@@ -1,0 +1,17 @@
+package com.example.exception.playground.global.exception;
+
+import com.example.exception.playground.global.error.ErrorCode;
+
+public class RequestInProgressException extends RuntimeException {
+
+    private final ErrorCode errorCode;
+
+    public RequestInProgressException(String message) {
+        super(message);
+        this.errorCode = ErrorCode.REQUEST_IN_PROGRESS;
+    }
+
+    public ErrorCode getErrorCode() {
+        return errorCode;
+    }
+}

--- a/src/main/java/com/example/exception/playground/global/exception/ServiceUnavailableException.java
+++ b/src/main/java/com/example/exception/playground/global/exception/ServiceUnavailableException.java
@@ -1,0 +1,22 @@
+package com.example.exception.playground.global.exception;
+
+import com.example.exception.playground.global.error.ErrorCode;
+
+public class ServiceUnavailableException extends GatewayException {
+
+    private final Long retryAfterSeconds;
+
+    public ServiceUnavailableException(String message) {
+        super(ErrorCode.SERVICE_UNAVAILABLE, message);
+        this.retryAfterSeconds = null;
+    }
+
+    public ServiceUnavailableException(String message, long retryAfterSeconds) {
+        super(ErrorCode.SERVICE_UNAVAILABLE, message);
+        this.retryAfterSeconds = retryAfterSeconds;
+    }
+
+    public Long getRetryAfterSeconds() {
+        return retryAfterSeconds;
+    }
+}

--- a/src/main/java/com/example/exception/playground/global/handler/GlobalExceptionHandler.java
+++ b/src/main/java/com/example/exception/playground/global/handler/GlobalExceptionHandler.java
@@ -3,9 +3,13 @@ package com.example.exception.playground.global.handler;
 import com.example.exception.playground.global.error.ErrorCode;
 import com.example.exception.playground.global.error.ErrorResponse;
 import com.example.exception.playground.global.exception.BusinessException;
+import com.example.exception.playground.global.exception.GatewayException;
+import com.example.exception.playground.global.exception.RequestInProgressException;
+import com.example.exception.playground.global.exception.ServiceUnavailableException;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Value;
+import org.springframework.http.HttpHeaders;
 import org.springframework.http.ResponseEntity;
 import org.springframework.http.converter.HttpMessageNotReadableException;
 import org.springframework.web.HttpMediaTypeNotSupportedException;
@@ -108,6 +112,40 @@ public class GlobalExceptionHandler {
                 ? ErrorResponse.withDebug(ErrorCode.RESOURCE_NOT_FOUND, e.getMessage(), e)
                 : ErrorResponse.of(ErrorCode.RESOURCE_NOT_FOUND, e.getMessage());
         return ResponseEntity.status(ErrorCode.RESOURCE_NOT_FOUND.getStatus()).body(response);
+    }
+
+    @ExceptionHandler(RequestInProgressException.class)
+    protected ResponseEntity<ErrorResponse> handleRequestInProgress(RequestInProgressException e) {
+        log.info("Request in progress: {}", e.getMessage());
+        ErrorCode errorCode = e.getErrorCode();
+        ErrorResponse response = debug
+                ? ErrorResponse.retryableWithDebug(errorCode, e.getMessage(), "POLL_STATUS", e)
+                : ErrorResponse.retryable(errorCode, e.getMessage(), "POLL_STATUS");
+        return ResponseEntity.status(errorCode.getStatus()).body(response);
+    }
+
+    @ExceptionHandler(ServiceUnavailableException.class)
+    protected ResponseEntity<ErrorResponse> handleServiceUnavailable(ServiceUnavailableException e) {
+        log.warn("Service unavailable: {}", e.getMessage());
+        ErrorCode errorCode = e.getErrorCode();
+        ErrorResponse response = debug
+                ? ErrorResponse.retryableWithDebug(errorCode, e.getMessage(), "RESUBMIT", e)
+                : ErrorResponse.retryable(errorCode, e.getMessage(), "RESUBMIT");
+        ResponseEntity.BodyBuilder builder = ResponseEntity.status(errorCode.getStatus());
+        if (e.getRetryAfterSeconds() != null) {
+            builder.header(HttpHeaders.RETRY_AFTER, String.valueOf(e.getRetryAfterSeconds()));
+        }
+        return builder.body(response);
+    }
+
+    @ExceptionHandler(GatewayException.class)
+    protected ResponseEntity<ErrorResponse> handleGatewayException(GatewayException e) {
+        log.error("Gateway error: {}", e.getMessage(), e);
+        ErrorCode errorCode = e.getErrorCode();
+        ErrorResponse response = debug
+                ? ErrorResponse.retryableWithDebug(errorCode, e.getMessage(), "RESUBMIT", e)
+                : ErrorResponse.retryable(errorCode, e.getMessage(), "RESUBMIT");
+        return ResponseEntity.status(errorCode.getStatus()).body(response);
     }
 
     @ExceptionHandler(BusinessException.class)

--- a/src/main/java/com/example/exception/playground/sample/adapter/in/web/SampleController.java
+++ b/src/main/java/com/example/exception/playground/sample/adapter/in/web/SampleController.java
@@ -3,7 +3,11 @@ package com.example.exception.playground.sample.adapter.in.web;
 import com.example.exception.playground.global.exception.AccessDeniedException;
 import com.example.exception.playground.global.exception.BusinessRuleViolationException;
 import com.example.exception.playground.global.exception.DuplicateResourceException;
+import com.example.exception.playground.global.exception.GatewayErrorException;
+import com.example.exception.playground.global.exception.GatewayTimeoutException;
 import com.example.exception.playground.global.exception.NotFoundException;
+import com.example.exception.playground.global.exception.RequestInProgressException;
+import com.example.exception.playground.global.exception.ServiceUnavailableException;
 import com.example.exception.playground.global.exception.UnauthorizedException;
 import jakarta.validation.Valid;
 import org.springframework.http.ResponseEntity;
@@ -62,5 +66,25 @@ public class SampleController {
     @GetMapping("/unexpected-error")
     public ResponseEntity<Void> unexpectedError() {
         throw new RuntimeException("Something went terribly wrong");
+    }
+
+    @GetMapping("/gateway-error")
+    public ResponseEntity<Void> gatewayError() {
+        throw new GatewayErrorException("Payment service connection refused");
+    }
+
+    @GetMapping("/gateway-timeout")
+    public ResponseEntity<Void> gatewayTimeout() {
+        throw new GatewayTimeoutException("Payment service did not respond within 5000ms");
+    }
+
+    @GetMapping("/service-unavailable")
+    public ResponseEntity<Void> serviceUnavailable() {
+        throw new ServiceUnavailableException("Payment service is under maintenance", 30);
+    }
+
+    @GetMapping("/request-in-progress")
+    public ResponseEntity<Void> requestInProgress() {
+        throw new RequestInProgressException("Request is being processed by payment service");
     }
 }

--- a/src/test/java/com/example/exception/playground/global/handler/GlobalExceptionHandlerTest.java
+++ b/src/test/java/com/example/exception/playground/global/handler/GlobalExceptionHandlerTest.java
@@ -198,6 +198,60 @@ class GlobalExceptionHandlerTest {
     }
 
     @Nested
+    @DisplayName("Gateway Errors (하위 서비스 통신 오류)")
+    class GatewayErrorTests {
+
+        @Test
+        @DisplayName("GatewayErrorException returns 502 with RESUBMIT strategy")
+        void gatewayError() throws Exception {
+            mockMvc.perform(get("/api/samples/gateway-error"))
+                    .andDo(print())
+                    .andExpect(status().isBadGateway())
+                    .andExpect(jsonPath("$.code").value("G001"))
+                    .andExpect(jsonPath("$.message").value("Payment service connection refused"))
+                    .andExpect(jsonPath("$.retryable").value(true))
+                    .andExpect(jsonPath("$.retryStrategy").value("RESUBMIT"));
+        }
+
+        @Test
+        @DisplayName("GatewayTimeoutException returns 504 with RESUBMIT strategy")
+        void gatewayTimeout() throws Exception {
+            mockMvc.perform(get("/api/samples/gateway-timeout"))
+                    .andDo(print())
+                    .andExpect(status().isGatewayTimeout())
+                    .andExpect(jsonPath("$.code").value("G002"))
+                    .andExpect(jsonPath("$.message").value("Payment service did not respond within 5000ms"))
+                    .andExpect(jsonPath("$.retryable").value(true))
+                    .andExpect(jsonPath("$.retryStrategy").value("RESUBMIT"));
+        }
+
+        @Test
+        @DisplayName("ServiceUnavailableException returns 503 with Retry-After header")
+        void serviceUnavailable() throws Exception {
+            mockMvc.perform(get("/api/samples/service-unavailable"))
+                    .andDo(print())
+                    .andExpect(status().isServiceUnavailable())
+                    .andExpect(jsonPath("$.code").value("G003"))
+                    .andExpect(jsonPath("$.message").value("Payment service is under maintenance"))
+                    .andExpect(jsonPath("$.retryable").value(true))
+                    .andExpect(jsonPath("$.retryStrategy").value("RESUBMIT"))
+                    .andExpect(header().string("Retry-After", "30"));
+        }
+
+        @Test
+        @DisplayName("RequestInProgressException returns 202 with POLL_STATUS strategy")
+        void requestInProgress() throws Exception {
+            mockMvc.perform(get("/api/samples/request-in-progress"))
+                    .andDo(print())
+                    .andExpect(status().isAccepted())
+                    .andExpect(jsonPath("$.code").value("P001"))
+                    .andExpect(jsonPath("$.message").value("Request is being processed by payment service"))
+                    .andExpect(jsonPath("$.retryable").value(true))
+                    .andExpect(jsonPath("$.retryStrategy").value("POLL_STATUS"));
+        }
+    }
+
+    @Nested
     @DisplayName("Unexpected Errors")
     class UnexpectedErrorTests {
 


### PR DESCRIPTION
## Summary

Closes #28

- 중계서비스에서 하위 서비스 통신 결과를 HTTP Status로 구분하여 응답
- `502 Bad Gateway`, `504 Gateway Timeout`, `503 Service Unavailable`, `202 Accepted` 추가
- `ErrorResponse`에 `retryable`, `retryStrategy` 필드 추가로 클라이언트 재시도 전략 안내

### HTTP Status 매핑

| 상황 | HTTP Status | retryStrategy |
|------|------------|---------------|
| 하위 서비스 연결 실패 | 502 | RESUBMIT |
| 하위 서비스 타임아웃 | 504 | RESUBMIT |
| 하위 서비스 과부하/점검 | 503 + Retry-After | RESUBMIT |
| 하위 서비스 처리 중 | 202 | POLL_STATUS |

## Test plan

- [x] GatewayErrorException → 502 + retryable + RESUBMIT 검증
- [x] GatewayTimeoutException → 504 + retryable + RESUBMIT 검증
- [x] ServiceUnavailableException → 503 + Retry-After 헤더 검증
- [x] RequestInProgressException → 202 + retryable + POLL_STATUS 검증
- [x] 기존 테스트 전체 통과 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)