### PR TITLE
test: Gateway/처리상태 예외 핸들러 테스트 보완

### DIFF
--- a/src/main/java/com/example/exception/playground/sample/adapter/in/web/SampleController.java
+++ b/src/main/java/com/example/exception/playground/sample/adapter/in/web/SampleController.java
@@ -83,6 +83,11 @@ public class SampleController {
         throw new ServiceUnavailableException("Payment service is under maintenance", 30);
     }
 
+    @GetMapping("/service-unavailable-no-retry")
+    public ResponseEntity<Void> serviceUnavailableNoRetry() {
+        throw new ServiceUnavailableException("Payment service is temporarily unavailable");
+    }
+
     @GetMapping("/request-in-progress")
     public ResponseEntity<Void> requestInProgress() {
         throw new RequestInProgressException("Request is being processed by payment service");

--- a/src/test/java/com/example/exception/playground/global/handler/GlobalExceptionHandlerDebugTest.java
+++ b/src/test/java/com/example/exception/playground/global/handler/GlobalExceptionHandlerDebugTest.java
@@ -78,6 +78,62 @@ class GlobalExceptionHandlerDebugTest {
     }
 
     @Nested
+    @DisplayName("Gateway Error in debug mode")
+    class GatewayErrorDebug {
+
+        @Test
+        @DisplayName("GatewayErrorException includes debug info with retryable fields")
+        void gatewayErrorWithDebug() throws Exception {
+            mockMvc.perform(get("/api/samples/gateway-error"))
+                    .andDo(print())
+                    .andExpect(status().isBadGateway())
+                    .andExpect(jsonPath("$.code").value("G001"))
+                    .andExpect(jsonPath("$.retryable").value(true))
+                    .andExpect(jsonPath("$.retryStrategy").value("RESUBMIT"))
+                    .andExpect(jsonPath("$.debugMessage").value("GatewayErrorException: Payment service connection refused"))
+                    .andExpect(jsonPath("$.stackTrace").exists());
+        }
+
+        @Test
+        @DisplayName("GatewayTimeoutException includes debug info")
+        void gatewayTimeoutWithDebug() throws Exception {
+            mockMvc.perform(get("/api/samples/gateway-timeout"))
+                    .andDo(print())
+                    .andExpect(status().isGatewayTimeout())
+                    .andExpect(jsonPath("$.code").value("G002"))
+                    .andExpect(jsonPath("$.retryable").value(true))
+                    .andExpect(jsonPath("$.debugMessage").value("GatewayTimeoutException: Payment service did not respond within 5000ms"))
+                    .andExpect(jsonPath("$.stackTrace").exists());
+        }
+
+        @Test
+        @DisplayName("ServiceUnavailableException includes debug info")
+        void serviceUnavailableWithDebug() throws Exception {
+            mockMvc.perform(get("/api/samples/service-unavailable"))
+                    .andDo(print())
+                    .andExpect(status().isServiceUnavailable())
+                    .andExpect(jsonPath("$.code").value("G003"))
+                    .andExpect(jsonPath("$.retryable").value(true))
+                    .andExpect(jsonPath("$.debugMessage").value("ServiceUnavailableException: Payment service is under maintenance"))
+                    .andExpect(jsonPath("$.stackTrace").exists())
+                    .andExpect(header().string("Retry-After", "30"));
+        }
+
+        @Test
+        @DisplayName("RequestInProgressException includes debug info with POLL_STATUS")
+        void requestInProgressWithDebug() throws Exception {
+            mockMvc.perform(get("/api/samples/request-in-progress"))
+                    .andDo(print())
+                    .andExpect(status().isAccepted())
+                    .andExpect(jsonPath("$.code").value("P001"))
+                    .andExpect(jsonPath("$.retryable").value(true))
+                    .andExpect(jsonPath("$.retryStrategy").value("POLL_STATUS"))
+                    .andExpect(jsonPath("$.debugMessage").value("RequestInProgressException: Request is being processed by payment service"))
+                    .andExpect(jsonPath("$.stackTrace").exists());
+        }
+    }
+
+    @Nested
     @DisplayName("Malformed JSON in debug mode")
     class MalformedJsonDebug {
 

--- a/src/test/java/com/example/exception/playground/global/handler/GlobalExceptionHandlerTest.java
+++ b/src/test/java/com/example/exception/playground/global/handler/GlobalExceptionHandlerTest.java
@@ -208,9 +208,12 @@ class GlobalExceptionHandlerTest {
                     .andDo(print())
                     .andExpect(status().isBadGateway())
                     .andExpect(jsonPath("$.code").value("G001"))
+                    .andExpect(jsonPath("$.status").value(502))
                     .andExpect(jsonPath("$.message").value("Payment service connection refused"))
                     .andExpect(jsonPath("$.retryable").value(true))
-                    .andExpect(jsonPath("$.retryStrategy").value("RESUBMIT"));
+                    .andExpect(jsonPath("$.retryStrategy").value("RESUBMIT"))
+                    .andExpect(jsonPath("$.traceId").exists())
+                    .andExpect(jsonPath("$.timestamp").exists());
         }
 
         @Test
@@ -220,9 +223,12 @@ class GlobalExceptionHandlerTest {
                     .andDo(print())
                     .andExpect(status().isGatewayTimeout())
                     .andExpect(jsonPath("$.code").value("G002"))
+                    .andExpect(jsonPath("$.status").value(504))
                     .andExpect(jsonPath("$.message").value("Payment service did not respond within 5000ms"))
                     .andExpect(jsonPath("$.retryable").value(true))
-                    .andExpect(jsonPath("$.retryStrategy").value("RESUBMIT"));
+                    .andExpect(jsonPath("$.retryStrategy").value("RESUBMIT"))
+                    .andExpect(jsonPath("$.traceId").exists())
+                    .andExpect(jsonPath("$.timestamp").exists());
         }
 
         @Test
@@ -232,10 +238,23 @@ class GlobalExceptionHandlerTest {
                     .andDo(print())
                     .andExpect(status().isServiceUnavailable())
                     .andExpect(jsonPath("$.code").value("G003"))
+                    .andExpect(jsonPath("$.status").value(503))
                     .andExpect(jsonPath("$.message").value("Payment service is under maintenance"))
                     .andExpect(jsonPath("$.retryable").value(true))
                     .andExpect(jsonPath("$.retryStrategy").value("RESUBMIT"))
                     .andExpect(header().string("Retry-After", "30"));
+        }
+
+        @Test
+        @DisplayName("ServiceUnavailableException without retryAfterSeconds does not include Retry-After header")
+        void serviceUnavailableWithoutRetryAfter() throws Exception {
+            mockMvc.perform(get("/api/samples/service-unavailable-no-retry"))
+                    .andDo(print())
+                    .andExpect(status().isServiceUnavailable())
+                    .andExpect(jsonPath("$.code").value("G003"))
+                    .andExpect(jsonPath("$.retryable").value(true))
+                    .andExpect(jsonPath("$.retryStrategy").value("RESUBMIT"))
+                    .andExpect(header().doesNotExist("Retry-After"));
         }
 
         @Test
@@ -245,9 +264,53 @@ class GlobalExceptionHandlerTest {
                     .andDo(print())
                     .andExpect(status().isAccepted())
                     .andExpect(jsonPath("$.code").value("P001"))
+                    .andExpect(jsonPath("$.status").value(202))
                     .andExpect(jsonPath("$.message").value("Request is being processed by payment service"))
                     .andExpect(jsonPath("$.retryable").value(true))
-                    .andExpect(jsonPath("$.retryStrategy").value("POLL_STATUS"));
+                    .andExpect(jsonPath("$.retryStrategy").value("POLL_STATUS"))
+                    .andExpect(jsonPath("$.traceId").exists())
+                    .andExpect(jsonPath("$.timestamp").exists());
+        }
+    }
+
+    @Nested
+    @DisplayName("Non-retryable responses should not contain retry fields")
+    class NonRetryableTests {
+
+        @Test
+        @DisplayName("Business exception response does not include retryable/retryStrategy")
+        void businessExceptionNoRetryFields() throws Exception {
+            mockMvc.perform(get("/api/samples/0"))
+                    .andDo(print())
+                    .andExpect(status().isNotFound())
+                    .andExpect(jsonPath("$.code").value("C006"))
+                    .andExpect(jsonPath("$.retryable").doesNotExist())
+                    .andExpect(jsonPath("$.retryStrategy").doesNotExist());
+        }
+
+        @Test
+        @DisplayName("Unexpected error response does not include retryable/retryStrategy")
+        void unexpectedErrorNoRetryFields() throws Exception {
+            mockMvc.perform(get("/api/samples/unexpected-error"))
+                    .andDo(print())
+                    .andExpect(status().isInternalServerError())
+                    .andExpect(jsonPath("$.code").value("C999"))
+                    .andExpect(jsonPath("$.retryable").doesNotExist())
+                    .andExpect(jsonPath("$.retryStrategy").doesNotExist());
+        }
+
+        @Test
+        @DisplayName("Validation error response does not include retryable/retryStrategy")
+        void validationErrorNoRetryFields() throws Exception {
+            mockMvc.perform(post("/api/samples")
+                            .contentType(MediaType.APPLICATION_JSON)
+                            .content("""
+                                    {"name": "", "age": 25}
+                                    """))
+                    .andDo(print())
+                    .andExpect(status().isBadRequest())
+                    .andExpect(jsonPath("$.retryable").doesNotExist())
+                    .andExpect(jsonPath("$.retryStrategy").doesNotExist());
         }
     }
 


### PR DESCRIPTION
## Summary

Closes #30

- 비재시도 응답에 `retryable`/`retryStrategy`가 포함되지 않는지 검증 추가
- Gateway 예외(502, 504, 503, 202) debug 모드 테스트 추가
- `Retry-After` 헤더 없는 503 케이스 테스트 추가
- Gateway 응답 공통 필드(`status`, `traceId`, `timestamp`) 검증 추가

## Test plan

- [x] 비재시도 응답 3건 (Business/Unexpected/Validation) retryable 부재 검증
- [x] Debug 모드 Gateway 4건 (502, 504, 503, 202) debugMessage/stackTrace 검증
- [x] Retry-After 헤더 유무 분기 테스트
- [x] 기존 테스트 전체 통과

🤖 Generated with [Claude Code](https://claude.com/claude-code)