### PR TITLE
refactor: SampleController를 HTTP Status 목적별로 분리

### DIFF
--- a/src/main/java/com/example/exception/playground/sample/adapter/in/web/SampleController.java
+++ b/src/main/java/com/example/exception/playground/sample/adapter/in/web/SampleController.java
@@ -1,14 +1,7 @@
 package com.example.exception.playground.sample.adapter.in.web;
 
-import com.example.exception.playground.global.exception.AccessDeniedException;
-import com.example.exception.playground.global.exception.BusinessRuleViolationException;
 import com.example.exception.playground.global.exception.DuplicateResourceException;
-import com.example.exception.playground.global.exception.GatewayErrorException;
-import com.example.exception.playground.global.exception.GatewayTimeoutException;
 import com.example.exception.playground.global.exception.NotFoundException;
-import com.example.exception.playground.global.exception.RequestInProgressException;
-import com.example.exception.playground.global.exception.ServiceUnavailableException;
-import com.example.exception.playground.global.exception.UnauthorizedException;
 import jakarta.validation.Valid;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
@@ -33,63 +26,5 @@ public class SampleController {
             throw new DuplicateResourceException("Sample with name 'duplicate' already exists");
         }
         return ResponseEntity.ok(Map.of("result", "created", "name", request.name()));
-    }
-
-    @GetMapping("/type-mismatch")
-    public ResponseEntity<Map<String, Object>> typeMismatch(@RequestParam Integer number) {
-        return ResponseEntity.ok(Map.of("number", number));
-    }
-
-    @GetMapping("/missing-param")
-    public ResponseEntity<Map<String, String>> missingParam(@RequestParam String required) {
-        return ResponseEntity.ok(Map.of("required", required));
-    }
-
-    @GetMapping("/unauthorized")
-    public ResponseEntity<Void> unauthorized() {
-        throw new UnauthorizedException("Invalid or expired token");
-    }
-
-    @GetMapping("/access-denied")
-    public ResponseEntity<Void> accessDenied() {
-        throw new AccessDeniedException("Insufficient permissions to access this resource");
-    }
-
-    @PostMapping("/business-rule")
-    public ResponseEntity<Map<String, String>> businessRule(@Valid @RequestBody SampleRequest request) {
-        if (request.age() > 100) {
-            throw new BusinessRuleViolationException("Age cannot exceed 100 for this operation");
-        }
-        return ResponseEntity.ok(Map.of("result", "ok"));
-    }
-
-    @GetMapping("/unexpected-error")
-    public ResponseEntity<Void> unexpectedError() {
-        throw new RuntimeException("Something went terribly wrong");
-    }
-
-    @GetMapping("/gateway-error")
-    public ResponseEntity<Void> gatewayError() {
-        throw new GatewayErrorException("Payment service connection refused");
-    }
-
-    @GetMapping("/gateway-timeout")
-    public ResponseEntity<Void> gatewayTimeout() {
-        throw new GatewayTimeoutException("Payment service did not respond within 5000ms");
-    }
-
-    @GetMapping("/service-unavailable")
-    public ResponseEntity<Void> serviceUnavailable() {
-        throw new ServiceUnavailableException("Payment service is under maintenance", 30);
-    }
-
-    @GetMapping("/service-unavailable-no-retry")
-    public ResponseEntity<Void> serviceUnavailableNoRetry() {
-        throw new ServiceUnavailableException("Payment service is temporarily unavailable");
-    }
-
-    @GetMapping("/request-in-progress")
-    public ResponseEntity<Void> requestInProgress() {
-        throw new RequestInProgressException("Request is being processed by payment service");
     }
 }

--- a/src/main/java/com/example/exception/playground/sample/adapter/in/web/SampleErrorController.java
+++ b/src/main/java/com/example/exception/playground/sample/adapter/in/web/SampleErrorController.java
@@ -1,0 +1,48 @@
+package com.example.exception.playground.sample.adapter.in.web;
+
+import com.example.exception.playground.global.exception.AccessDeniedException;
+import com.example.exception.playground.global.exception.BusinessRuleViolationException;
+import com.example.exception.playground.global.exception.UnauthorizedException;
+import jakarta.validation.Valid;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.Map;
+
+@RestController
+@RequestMapping("/api/samples")
+public class SampleErrorController {
+
+    @GetMapping("/type-mismatch")
+    public ResponseEntity<Map<String, Object>> typeMismatch(@RequestParam Integer number) {
+        return ResponseEntity.ok(Map.of("number", number));
+    }
+
+    @GetMapping("/missing-param")
+    public ResponseEntity<Map<String, String>> missingParam(@RequestParam String required) {
+        return ResponseEntity.ok(Map.of("required", required));
+    }
+
+    @GetMapping("/unauthorized")
+    public ResponseEntity<Void> unauthorized() {
+        throw new UnauthorizedException("Invalid or expired token");
+    }
+
+    @GetMapping("/access-denied")
+    public ResponseEntity<Void> accessDenied() {
+        throw new AccessDeniedException("Insufficient permissions to access this resource");
+    }
+
+    @PostMapping("/business-rule")
+    public ResponseEntity<Map<String, String>> businessRule(@Valid @RequestBody SampleRequest request) {
+        if (request.age() > 100) {
+            throw new BusinessRuleViolationException("Age cannot exceed 100 for this operation");
+        }
+        return ResponseEntity.ok(Map.of("result", "ok"));
+    }
+
+    @GetMapping("/unexpected-error")
+    public ResponseEntity<Void> unexpectedError() {
+        throw new RuntimeException("Something went terribly wrong");
+    }
+}

--- a/src/main/java/com/example/exception/playground/sample/adapter/in/web/SampleGatewayController.java
+++ b/src/main/java/com/example/exception/playground/sample/adapter/in/web/SampleGatewayController.java
@@ -1,0 +1,40 @@
+package com.example.exception.playground.sample.adapter.in.web;
+
+import com.example.exception.playground.global.exception.GatewayErrorException;
+import com.example.exception.playground.global.exception.GatewayTimeoutException;
+import com.example.exception.playground.global.exception.RequestInProgressException;
+import com.example.exception.playground.global.exception.ServiceUnavailableException;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping("/api/samples")
+public class SampleGatewayController {
+
+    @GetMapping("/gateway-error")
+    public ResponseEntity<Void> gatewayError() {
+        throw new GatewayErrorException("Payment service connection refused");
+    }
+
+    @GetMapping("/gateway-timeout")
+    public ResponseEntity<Void> gatewayTimeout() {
+        throw new GatewayTimeoutException("Payment service did not respond within 5000ms");
+    }
+
+    @GetMapping("/service-unavailable")
+    public ResponseEntity<Void> serviceUnavailable() {
+        throw new ServiceUnavailableException("Payment service is under maintenance", 30);
+    }
+
+    @GetMapping("/service-unavailable-no-retry")
+    public ResponseEntity<Void> serviceUnavailableNoRetry() {
+        throw new ServiceUnavailableException("Payment service is temporarily unavailable");
+    }
+
+    @GetMapping("/request-in-progress")
+    public ResponseEntity<Void> requestInProgress() {
+        throw new RequestInProgressException("Request is being processed by payment service");
+    }
+}

--- a/src/test/java/com/example/exception/playground/global/handler/ErrorExceptionHandlerDebugTest.java
+++ b/src/test/java/com/example/exception/playground/global/handler/ErrorExceptionHandlerDebugTest.java
@@ -1,0 +1,40 @@
+package com.example.exception.playground.global.handler;
+
+import com.example.exception.playground.sample.adapter.in.web.SampleErrorController;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.test.context.TestPropertySource;
+import org.springframework.test.web.servlet.MockMvc;
+
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
+
+@WebMvcTest(SampleErrorController.class)
+@TestPropertySource(properties = "app.debug=true")
+@DisplayName("Debug Mode - SampleErrorController")
+class ErrorExceptionHandlerDebugTest {
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @Nested
+    @DisplayName("Unexpected Error in debug mode")
+    class UnexpectedErrorDebug {
+
+        @Test
+        @DisplayName("RuntimeException includes full debug info")
+        void unexpectedErrorWithDebug() throws Exception {
+            mockMvc.perform(get("/api/samples/unexpected-error"))
+                    .andDo(print())
+                    .andExpect(status().isInternalServerError())
+                    .andExpect(jsonPath("$.code").value("C999"))
+                    .andExpect(jsonPath("$.traceId").exists())
+                    .andExpect(jsonPath("$.debugMessage").value("RuntimeException: Something went terribly wrong"))
+                    .andExpect(jsonPath("$.stackTrace").exists());
+        }
+    }
+}

--- a/src/test/java/com/example/exception/playground/global/handler/ErrorExceptionHandlerTest.java
+++ b/src/test/java/com/example/exception/playground/global/handler/ErrorExceptionHandlerTest.java
@@ -1,0 +1,122 @@
+package com.example.exception.playground.global.handler;
+
+import com.example.exception.playground.sample.adapter.in.web.SampleErrorController;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.http.MediaType;
+import org.springframework.test.web.servlet.MockMvc;
+
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
+
+@WebMvcTest(SampleErrorController.class)
+class ErrorExceptionHandlerTest {
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @Nested
+    @DisplayName("Type Mismatch (MethodArgumentTypeMismatchException)")
+    class TypeMismatchTests {
+
+        @Test
+        @DisplayName("string for integer param returns 400")
+        void typeMismatch() throws Exception {
+            mockMvc.perform(get("/api/samples/type-mismatch")
+                            .param("number", "abc"))
+                    .andDo(print())
+                    .andExpect(status().isBadRequest())
+                    .andExpect(jsonPath("$.code").value("C001"))
+                    .andExpect(jsonPath("$.message").value("'number' should be of type 'Integer'"));
+        }
+    }
+
+    @Nested
+    @DisplayName("Missing Parameter (MissingServletRequestParameterException)")
+    class MissingParameterTests {
+
+        @Test
+        @DisplayName("missing required query param returns 400")
+        void missingParam() throws Exception {
+            mockMvc.perform(get("/api/samples/missing-param"))
+                    .andDo(print())
+                    .andExpect(status().isBadRequest())
+                    .andExpect(jsonPath("$.code").value("C002"))
+                    .andExpect(jsonPath("$.message").value("Required parameter 'required' of type 'String' is missing"));
+        }
+    }
+
+    @Nested
+    @DisplayName("Auth Exceptions")
+    class AuthExceptionTests {
+
+        @Test
+        @DisplayName("UnauthorizedException returns 401")
+        void unauthorized() throws Exception {
+            mockMvc.perform(get("/api/samples/unauthorized"))
+                    .andDo(print())
+                    .andExpect(status().isUnauthorized())
+                    .andExpect(jsonPath("$.code").value("A001"))
+                    .andExpect(jsonPath("$.message").value("Invalid or expired token"));
+        }
+
+        @Test
+        @DisplayName("AccessDeniedException returns 403")
+        void accessDenied() throws Exception {
+            mockMvc.perform(get("/api/samples/access-denied"))
+                    .andDo(print())
+                    .andExpect(status().isForbidden())
+                    .andExpect(jsonPath("$.code").value("A002"))
+                    .andExpect(jsonPath("$.message").value("Insufficient permissions to access this resource"));
+        }
+    }
+
+    @Nested
+    @DisplayName("Business Rule Violation")
+    class BusinessRuleTests {
+
+        @Test
+        @DisplayName("BusinessRuleViolationException returns 422")
+        void businessRuleViolation() throws Exception {
+            mockMvc.perform(post("/api/samples/business-rule")
+                            .contentType(MediaType.APPLICATION_JSON)
+                            .content("""
+                                    {"name": "test", "age": 150}
+                                    """))
+                    .andDo(print())
+                    .andExpect(status().isUnprocessableEntity())
+                    .andExpect(jsonPath("$.code").value("B002"))
+                    .andExpect(jsonPath("$.message").value("Age cannot exceed 100 for this operation"));
+        }
+    }
+
+    @Nested
+    @DisplayName("Unexpected Errors")
+    class UnexpectedErrorTests {
+
+        @Test
+        @DisplayName("RuntimeException returns 500")
+        void unexpectedError() throws Exception {
+            mockMvc.perform(get("/api/samples/unexpected-error"))
+                    .andDo(print())
+                    .andExpect(status().isInternalServerError())
+                    .andExpect(jsonPath("$.code").value("C999"))
+                    .andExpect(jsonPath("$.message").value("Internal server error"));
+        }
+
+        @Test
+        @DisplayName("Unexpected error response does not include retryable/retryStrategy")
+        void unexpectedErrorNoRetryFields() throws Exception {
+            mockMvc.perform(get("/api/samples/unexpected-error"))
+                    .andDo(print())
+                    .andExpect(status().isInternalServerError())
+                    .andExpect(jsonPath("$.retryable").doesNotExist())
+                    .andExpect(jsonPath("$.retryStrategy").doesNotExist());
+        }
+    }
+}

--- a/src/test/java/com/example/exception/playground/global/handler/GatewayExceptionHandlerDebugTest.java
+++ b/src/test/java/com/example/exception/playground/global/handler/GatewayExceptionHandlerDebugTest.java
@@ -1,0 +1,94 @@
+package com.example.exception.playground.global.handler;
+
+import com.example.exception.playground.sample.adapter.in.web.SampleGatewayController;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.test.context.TestPropertySource;
+import org.springframework.test.web.servlet.MockMvc;
+
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
+
+@WebMvcTest(SampleGatewayController.class)
+@TestPropertySource(properties = "app.debug=true")
+@DisplayName("Debug Mode - SampleGatewayController")
+class GatewayExceptionHandlerDebugTest {
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @Nested
+    @DisplayName("502 Bad Gateway in debug mode")
+    class GatewayErrorDebug {
+
+        @Test
+        @DisplayName("GatewayErrorException includes debug info with retryable fields")
+        void gatewayErrorWithDebug() throws Exception {
+            mockMvc.perform(get("/api/samples/gateway-error"))
+                    .andDo(print())
+                    .andExpect(status().isBadGateway())
+                    .andExpect(jsonPath("$.code").value("G001"))
+                    .andExpect(jsonPath("$.retryable").value(true))
+                    .andExpect(jsonPath("$.retryStrategy").value("RESUBMIT"))
+                    .andExpect(jsonPath("$.debugMessage").value("GatewayErrorException: Payment service connection refused"))
+                    .andExpect(jsonPath("$.stackTrace").exists());
+        }
+    }
+
+    @Nested
+    @DisplayName("504 Gateway Timeout in debug mode")
+    class GatewayTimeoutDebug {
+
+        @Test
+        @DisplayName("GatewayTimeoutException includes debug info")
+        void gatewayTimeoutWithDebug() throws Exception {
+            mockMvc.perform(get("/api/samples/gateway-timeout"))
+                    .andDo(print())
+                    .andExpect(status().isGatewayTimeout())
+                    .andExpect(jsonPath("$.code").value("G002"))
+                    .andExpect(jsonPath("$.retryable").value(true))
+                    .andExpect(jsonPath("$.debugMessage").value("GatewayTimeoutException: Payment service did not respond within 5000ms"))
+                    .andExpect(jsonPath("$.stackTrace").exists());
+        }
+    }
+
+    @Nested
+    @DisplayName("503 Service Unavailable in debug mode")
+    class ServiceUnavailableDebug {
+
+        @Test
+        @DisplayName("ServiceUnavailableException includes debug info")
+        void serviceUnavailableWithDebug() throws Exception {
+            mockMvc.perform(get("/api/samples/service-unavailable"))
+                    .andDo(print())
+                    .andExpect(status().isServiceUnavailable())
+                    .andExpect(jsonPath("$.code").value("G003"))
+                    .andExpect(jsonPath("$.retryable").value(true))
+                    .andExpect(jsonPath("$.debugMessage").value("ServiceUnavailableException: Payment service is under maintenance"))
+                    .andExpect(jsonPath("$.stackTrace").exists())
+                    .andExpect(header().string("Retry-After", "30"));
+        }
+    }
+
+    @Nested
+    @DisplayName("202 Accepted in debug mode")
+    class RequestInProgressDebug {
+
+        @Test
+        @DisplayName("RequestInProgressException includes debug info with POLL_STATUS")
+        void requestInProgressWithDebug() throws Exception {
+            mockMvc.perform(get("/api/samples/request-in-progress"))
+                    .andDo(print())
+                    .andExpect(status().isAccepted())
+                    .andExpect(jsonPath("$.code").value("P001"))
+                    .andExpect(jsonPath("$.retryable").value(true))
+                    .andExpect(jsonPath("$.retryStrategy").value("POLL_STATUS"))
+                    .andExpect(jsonPath("$.debugMessage").value("RequestInProgressException: Request is being processed by payment service"))
+                    .andExpect(jsonPath("$.stackTrace").exists());
+        }
+    }
+}

--- a/src/test/java/com/example/exception/playground/global/handler/GatewayExceptionHandlerTest.java
+++ b/src/test/java/com/example/exception/playground/global/handler/GatewayExceptionHandlerTest.java
@@ -1,0 +1,111 @@
+package com.example.exception.playground.global.handler;
+
+import com.example.exception.playground.sample.adapter.in.web.SampleGatewayController;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.test.web.servlet.MockMvc;
+
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
+
+@WebMvcTest(SampleGatewayController.class)
+class GatewayExceptionHandlerTest {
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @Nested
+    @DisplayName("502 Bad Gateway - 하위 서비스 연결 실패")
+    class BadGatewayTests {
+
+        @Test
+        @DisplayName("GatewayErrorException returns 502 with RESUBMIT strategy")
+        void gatewayError() throws Exception {
+            mockMvc.perform(get("/api/samples/gateway-error"))
+                    .andDo(print())
+                    .andExpect(status().isBadGateway())
+                    .andExpect(jsonPath("$.code").value("G001"))
+                    .andExpect(jsonPath("$.status").value(502))
+                    .andExpect(jsonPath("$.message").value("Payment service connection refused"))
+                    .andExpect(jsonPath("$.retryable").value(true))
+                    .andExpect(jsonPath("$.retryStrategy").value("RESUBMIT"))
+                    .andExpect(jsonPath("$.traceId").exists())
+                    .andExpect(jsonPath("$.timestamp").exists());
+        }
+    }
+
+    @Nested
+    @DisplayName("504 Gateway Timeout - 하위 서비스 응답 시간 초과")
+    class GatewayTimeoutTests {
+
+        @Test
+        @DisplayName("GatewayTimeoutException returns 504 with RESUBMIT strategy")
+        void gatewayTimeout() throws Exception {
+            mockMvc.perform(get("/api/samples/gateway-timeout"))
+                    .andDo(print())
+                    .andExpect(status().isGatewayTimeout())
+                    .andExpect(jsonPath("$.code").value("G002"))
+                    .andExpect(jsonPath("$.status").value(504))
+                    .andExpect(jsonPath("$.message").value("Payment service did not respond within 5000ms"))
+                    .andExpect(jsonPath("$.retryable").value(true))
+                    .andExpect(jsonPath("$.retryStrategy").value("RESUBMIT"))
+                    .andExpect(jsonPath("$.traceId").exists())
+                    .andExpect(jsonPath("$.timestamp").exists());
+        }
+    }
+
+    @Nested
+    @DisplayName("503 Service Unavailable - 하위 서비스 과부하/점검")
+    class ServiceUnavailableTests {
+
+        @Test
+        @DisplayName("ServiceUnavailableException returns 503 with Retry-After header")
+        void serviceUnavailableWithRetryAfter() throws Exception {
+            mockMvc.perform(get("/api/samples/service-unavailable"))
+                    .andDo(print())
+                    .andExpect(status().isServiceUnavailable())
+                    .andExpect(jsonPath("$.code").value("G003"))
+                    .andExpect(jsonPath("$.status").value(503))
+                    .andExpect(jsonPath("$.message").value("Payment service is under maintenance"))
+                    .andExpect(jsonPath("$.retryable").value(true))
+                    .andExpect(jsonPath("$.retryStrategy").value("RESUBMIT"))
+                    .andExpect(header().string("Retry-After", "30"));
+        }
+
+        @Test
+        @DisplayName("ServiceUnavailableException without retryAfterSeconds does not include Retry-After header")
+        void serviceUnavailableWithoutRetryAfter() throws Exception {
+            mockMvc.perform(get("/api/samples/service-unavailable-no-retry"))
+                    .andDo(print())
+                    .andExpect(status().isServiceUnavailable())
+                    .andExpect(jsonPath("$.code").value("G003"))
+                    .andExpect(jsonPath("$.retryable").value(true))
+                    .andExpect(jsonPath("$.retryStrategy").value("RESUBMIT"))
+                    .andExpect(header().doesNotExist("Retry-After"));
+        }
+    }
+
+    @Nested
+    @DisplayName("202 Accepted - 하위 서비스 처리 중")
+    class RequestInProgressTests {
+
+        @Test
+        @DisplayName("RequestInProgressException returns 202 with POLL_STATUS strategy")
+        void requestInProgress() throws Exception {
+            mockMvc.perform(get("/api/samples/request-in-progress"))
+                    .andDo(print())
+                    .andExpect(status().isAccepted())
+                    .andExpect(jsonPath("$.code").value("P001"))
+                    .andExpect(jsonPath("$.status").value(202))
+                    .andExpect(jsonPath("$.message").value("Request is being processed by payment service"))
+                    .andExpect(jsonPath("$.retryable").value(true))
+                    .andExpect(jsonPath("$.retryStrategy").value("POLL_STATUS"))
+                    .andExpect(jsonPath("$.traceId").exists())
+                    .andExpect(jsonPath("$.timestamp").exists());
+        }
+    }
+}

--- a/src/test/java/com/example/exception/playground/global/handler/GlobalExceptionHandlerDebugTest.java
+++ b/src/test/java/com/example/exception/playground/global/handler/GlobalExceptionHandlerDebugTest.java
@@ -17,7 +17,7 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 
 @WebMvcTest(SampleController.class)
 @TestPropertySource(properties = "app.debug=true")
-@DisplayName("Debug Mode - ErrorResponse includes debugMessage and stackTrace")
+@DisplayName("Debug Mode - SampleController")
 class GlobalExceptionHandlerDebugTest {
 
     @Autowired
@@ -56,79 +56,6 @@ class GlobalExceptionHandlerDebugTest {
                     .andExpect(jsonPath("$.code").value("C006"))
                     .andExpect(jsonPath("$.traceId").exists())
                     .andExpect(jsonPath("$.debugMessage").value("NotFoundException: Sample with id 0 not found"))
-                    .andExpect(jsonPath("$.stackTrace").exists());
-        }
-    }
-
-    @Nested
-    @DisplayName("Unexpected Error in debug mode")
-    class UnexpectedErrorDebug {
-
-        @Test
-        @DisplayName("RuntimeException includes full debug info")
-        void unexpectedErrorWithDebug() throws Exception {
-            mockMvc.perform(get("/api/samples/unexpected-error"))
-                    .andDo(print())
-                    .andExpect(status().isInternalServerError())
-                    .andExpect(jsonPath("$.code").value("C999"))
-                    .andExpect(jsonPath("$.traceId").exists())
-                    .andExpect(jsonPath("$.debugMessage").value("RuntimeException: Something went terribly wrong"))
-                    .andExpect(jsonPath("$.stackTrace").exists());
-        }
-    }
-
-    @Nested
-    @DisplayName("Gateway Error in debug mode")
-    class GatewayErrorDebug {
-
-        @Test
-        @DisplayName("GatewayErrorException includes debug info with retryable fields")
-        void gatewayErrorWithDebug() throws Exception {
-            mockMvc.perform(get("/api/samples/gateway-error"))
-                    .andDo(print())
-                    .andExpect(status().isBadGateway())
-                    .andExpect(jsonPath("$.code").value("G001"))
-                    .andExpect(jsonPath("$.retryable").value(true))
-                    .andExpect(jsonPath("$.retryStrategy").value("RESUBMIT"))
-                    .andExpect(jsonPath("$.debugMessage").value("GatewayErrorException: Payment service connection refused"))
-                    .andExpect(jsonPath("$.stackTrace").exists());
-        }
-
-        @Test
-        @DisplayName("GatewayTimeoutException includes debug info")
-        void gatewayTimeoutWithDebug() throws Exception {
-            mockMvc.perform(get("/api/samples/gateway-timeout"))
-                    .andDo(print())
-                    .andExpect(status().isGatewayTimeout())
-                    .andExpect(jsonPath("$.code").value("G002"))
-                    .andExpect(jsonPath("$.retryable").value(true))
-                    .andExpect(jsonPath("$.debugMessage").value("GatewayTimeoutException: Payment service did not respond within 5000ms"))
-                    .andExpect(jsonPath("$.stackTrace").exists());
-        }
-
-        @Test
-        @DisplayName("ServiceUnavailableException includes debug info")
-        void serviceUnavailableWithDebug() throws Exception {
-            mockMvc.perform(get("/api/samples/service-unavailable"))
-                    .andDo(print())
-                    .andExpect(status().isServiceUnavailable())
-                    .andExpect(jsonPath("$.code").value("G003"))
-                    .andExpect(jsonPath("$.retryable").value(true))
-                    .andExpect(jsonPath("$.debugMessage").value("ServiceUnavailableException: Payment service is under maintenance"))
-                    .andExpect(jsonPath("$.stackTrace").exists())
-                    .andExpect(header().string("Retry-After", "30"));
-        }
-
-        @Test
-        @DisplayName("RequestInProgressException includes debug info with POLL_STATUS")
-        void requestInProgressWithDebug() throws Exception {
-            mockMvc.perform(get("/api/samples/request-in-progress"))
-                    .andDo(print())
-                    .andExpect(status().isAccepted())
-                    .andExpect(jsonPath("$.code").value("P001"))
-                    .andExpect(jsonPath("$.retryable").value(true))
-                    .andExpect(jsonPath("$.retryStrategy").value("POLL_STATUS"))
-                    .andExpect(jsonPath("$.debugMessage").value("RequestInProgressException: Request is being processed by payment service"))
                     .andExpect(jsonPath("$.stackTrace").exists());
         }
     }

--- a/src/test/java/com/example/exception/playground/global/handler/GlobalExceptionHandlerTest.java
+++ b/src/test/java/com/example/exception/playground/global/handler/GlobalExceptionHandlerTest.java
@@ -57,22 +57,6 @@ class GlobalExceptionHandlerTest {
     }
 
     @Nested
-    @DisplayName("Type Mismatch (MethodArgumentTypeMismatchException)")
-    class TypeMismatchTests {
-
-        @Test
-        @DisplayName("string for integer param returns 400")
-        void typeMismatch() throws Exception {
-            mockMvc.perform(get("/api/samples/type-mismatch")
-                            .param("number", "abc"))
-                    .andDo(print())
-                    .andExpect(status().isBadRequest())
-                    .andExpect(jsonPath("$.code").value("C001"))
-                    .andExpect(jsonPath("$.message").value("'number' should be of type 'Integer'"));
-        }
-    }
-
-    @Nested
     @DisplayName("Method Not Allowed")
     class MethodNotAllowedTests {
 
@@ -83,21 +67,6 @@ class GlobalExceptionHandlerTest {
                     .andDo(print())
                     .andExpect(status().isMethodNotAllowed())
                     .andExpect(jsonPath("$.code").value("C005"));
-        }
-    }
-
-    @Nested
-    @DisplayName("Missing Parameter (MissingServletRequestParameterException)")
-    class MissingParameterTests {
-
-        @Test
-        @DisplayName("missing required query param returns 400")
-        void missingParam() throws Exception {
-            mockMvc.perform(get("/api/samples/missing-param"))
-                    .andDo(print())
-                    .andExpect(status().isBadRequest())
-                    .andExpect(jsonPath("$.code").value("C002"))
-                    .andExpect(jsonPath("$.message").value("Required parameter 'required' of type 'String' is missing"));
         }
     }
 
@@ -149,40 +118,6 @@ class GlobalExceptionHandlerTest {
         }
 
         @Test
-        @DisplayName("UnauthorizedException returns 401")
-        void unauthorized() throws Exception {
-            mockMvc.perform(get("/api/samples/unauthorized"))
-                    .andDo(print())
-                    .andExpect(status().isUnauthorized())
-                    .andExpect(jsonPath("$.code").value("A001"))
-                    .andExpect(jsonPath("$.message").value("Invalid or expired token"));
-        }
-
-        @Test
-        @DisplayName("AccessDeniedException returns 403")
-        void accessDenied() throws Exception {
-            mockMvc.perform(get("/api/samples/access-denied"))
-                    .andDo(print())
-                    .andExpect(status().isForbidden())
-                    .andExpect(jsonPath("$.code").value("A002"))
-                    .andExpect(jsonPath("$.message").value("Insufficient permissions to access this resource"));
-        }
-
-        @Test
-        @DisplayName("BusinessRuleViolationException returns 422")
-        void businessRuleViolation() throws Exception {
-            mockMvc.perform(post("/api/samples/business-rule")
-                            .contentType(MediaType.APPLICATION_JSON)
-                            .content("""
-                                    {"name": "test", "age": 150}
-                                    """))
-                    .andDo(print())
-                    .andExpect(status().isUnprocessableEntity())
-                    .andExpect(jsonPath("$.code").value("B002"))
-                    .andExpect(jsonPath("$.message").value("Age cannot exceed 100 for this operation"));
-        }
-
-        @Test
         @DisplayName("DuplicateResourceException returns 409")
         void duplicate() throws Exception {
             mockMvc.perform(post("/api/samples")
@@ -194,82 +129,6 @@ class GlobalExceptionHandlerTest {
                     .andExpect(status().isConflict())
                     .andExpect(jsonPath("$.code").value("B001"))
                     .andExpect(jsonPath("$.message").value("Sample with name 'duplicate' already exists"));
-        }
-    }
-
-    @Nested
-    @DisplayName("Gateway Errors (하위 서비스 통신 오류)")
-    class GatewayErrorTests {
-
-        @Test
-        @DisplayName("GatewayErrorException returns 502 with RESUBMIT strategy")
-        void gatewayError() throws Exception {
-            mockMvc.perform(get("/api/samples/gateway-error"))
-                    .andDo(print())
-                    .andExpect(status().isBadGateway())
-                    .andExpect(jsonPath("$.code").value("G001"))
-                    .andExpect(jsonPath("$.status").value(502))
-                    .andExpect(jsonPath("$.message").value("Payment service connection refused"))
-                    .andExpect(jsonPath("$.retryable").value(true))
-                    .andExpect(jsonPath("$.retryStrategy").value("RESUBMIT"))
-                    .andExpect(jsonPath("$.traceId").exists())
-                    .andExpect(jsonPath("$.timestamp").exists());
-        }
-
-        @Test
-        @DisplayName("GatewayTimeoutException returns 504 with RESUBMIT strategy")
-        void gatewayTimeout() throws Exception {
-            mockMvc.perform(get("/api/samples/gateway-timeout"))
-                    .andDo(print())
-                    .andExpect(status().isGatewayTimeout())
-                    .andExpect(jsonPath("$.code").value("G002"))
-                    .andExpect(jsonPath("$.status").value(504))
-                    .andExpect(jsonPath("$.message").value("Payment service did not respond within 5000ms"))
-                    .andExpect(jsonPath("$.retryable").value(true))
-                    .andExpect(jsonPath("$.retryStrategy").value("RESUBMIT"))
-                    .andExpect(jsonPath("$.traceId").exists())
-                    .andExpect(jsonPath("$.timestamp").exists());
-        }
-
-        @Test
-        @DisplayName("ServiceUnavailableException returns 503 with Retry-After header")
-        void serviceUnavailable() throws Exception {
-            mockMvc.perform(get("/api/samples/service-unavailable"))
-                    .andDo(print())
-                    .andExpect(status().isServiceUnavailable())
-                    .andExpect(jsonPath("$.code").value("G003"))
-                    .andExpect(jsonPath("$.status").value(503))
-                    .andExpect(jsonPath("$.message").value("Payment service is under maintenance"))
-                    .andExpect(jsonPath("$.retryable").value(true))
-                    .andExpect(jsonPath("$.retryStrategy").value("RESUBMIT"))
-                    .andExpect(header().string("Retry-After", "30"));
-        }
-
-        @Test
-        @DisplayName("ServiceUnavailableException without retryAfterSeconds does not include Retry-After header")
-        void serviceUnavailableWithoutRetryAfter() throws Exception {
-            mockMvc.perform(get("/api/samples/service-unavailable-no-retry"))
-                    .andDo(print())
-                    .andExpect(status().isServiceUnavailable())
-                    .andExpect(jsonPath("$.code").value("G003"))
-                    .andExpect(jsonPath("$.retryable").value(true))
-                    .andExpect(jsonPath("$.retryStrategy").value("RESUBMIT"))
-                    .andExpect(header().doesNotExist("Retry-After"));
-        }
-
-        @Test
-        @DisplayName("RequestInProgressException returns 202 with POLL_STATUS strategy")
-        void requestInProgress() throws Exception {
-            mockMvc.perform(get("/api/samples/request-in-progress"))
-                    .andDo(print())
-                    .andExpect(status().isAccepted())
-                    .andExpect(jsonPath("$.code").value("P001"))
-                    .andExpect(jsonPath("$.status").value(202))
-                    .andExpect(jsonPath("$.message").value("Request is being processed by payment service"))
-                    .andExpect(jsonPath("$.retryable").value(true))
-                    .andExpect(jsonPath("$.retryStrategy").value("POLL_STATUS"))
-                    .andExpect(jsonPath("$.traceId").exists())
-                    .andExpect(jsonPath("$.timestamp").exists());
         }
     }
 
@@ -289,17 +148,6 @@ class GlobalExceptionHandlerTest {
         }
 
         @Test
-        @DisplayName("Unexpected error response does not include retryable/retryStrategy")
-        void unexpectedErrorNoRetryFields() throws Exception {
-            mockMvc.perform(get("/api/samples/unexpected-error"))
-                    .andDo(print())
-                    .andExpect(status().isInternalServerError())
-                    .andExpect(jsonPath("$.code").value("C999"))
-                    .andExpect(jsonPath("$.retryable").doesNotExist())
-                    .andExpect(jsonPath("$.retryStrategy").doesNotExist());
-        }
-
-        @Test
         @DisplayName("Validation error response does not include retryable/retryStrategy")
         void validationErrorNoRetryFields() throws Exception {
             mockMvc.perform(post("/api/samples")
@@ -311,21 +159,6 @@ class GlobalExceptionHandlerTest {
                     .andExpect(status().isBadRequest())
                     .andExpect(jsonPath("$.retryable").doesNotExist())
                     .andExpect(jsonPath("$.retryStrategy").doesNotExist());
-        }
-    }
-
-    @Nested
-    @DisplayName("Unexpected Errors")
-    class UnexpectedErrorTests {
-
-        @Test
-        @DisplayName("RuntimeException returns 500")
-        void unexpectedError() throws Exception {
-            mockMvc.perform(get("/api/samples/unexpected-error"))
-                    .andDo(print())
-                    .andExpect(status().isInternalServerError())
-                    .andExpect(jsonPath("$.code").value("C999"))
-                    .andExpect(jsonPath("$.message").value("Internal server error"));
         }
     }
 }


### PR DESCRIPTION
## Summary

Closes #32

SampleController에 혼재된 엔드포인트를 HTTP Status 목적별로 3개 컨트롤러로 분리.

| 컨트롤러 | 담당 | HTTP Status |
|----------|------|-------------|
| `SampleController` | 정상 비즈니스 로직 | 200, 404, 409 |
| `SampleErrorController` | 입력/인증/비즈니스 예외 | 400, 401, 403, 422, 500 |
| `SampleGatewayController` | Gateway/처리상태 예외 | 202, 502, 503, 504 |

테스트 클래스도 동일하게 분리:
- `GlobalExceptionHandlerTest` / `GlobalExceptionHandlerDebugTest` → SampleController
- `ErrorExceptionHandlerTest` / `ErrorExceptionHandlerDebugTest` → SampleErrorController
- `GatewayExceptionHandlerTest` / `GatewayExceptionHandlerDebugTest` → SampleGatewayController

## Test plan

- [x] 전체 테스트 통과 확인
- [x] 각 `@WebMvcTest`가 해당 컨트롤러만 로드하는지 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)