### PR TITLE
fix: RequestResponseLoggingFilter 응답 헤더 로깅 누락 수정

### DIFF
--- a/src/main/java/com/example/exception/playground/global/filter/RequestResponseLoggingFilter.java
+++ b/src/main/java/com/example/exception/playground/global/filter/RequestResponseLoggingFilter.java
@@ -63,13 +63,18 @@ public class RequestResponseLoggingFilter extends OncePerRequestFilter {
         int status = response.getStatus();
         String body = new String(response.getContentAsByteArray(), StandardCharsets.UTF_8);
 
+        StringBuilder headers = new StringBuilder();
+        response.getHeaderNames().forEach(name ->
+                headers.append(name).append(": ").append(response.getHeader(name)).append(", "));
+
         String requestBody = new String(request.getContentAsByteArray(), StandardCharsets.UTF_8);
         if (!requestBody.isBlank()) {
             log.info("[{}] >>> Request Body: {}", traceId, requestBody);
         }
 
-        String responseLog = String.format("[%s] <<< %s %s | Status: %d | %dms%s",
+        String responseLog = String.format("[%s] <<< %s %s | Status: %d | %dms | Headers: [%s]%s",
                 traceId, request.getMethod(), request.getRequestURI(), status, duration,
+                headers.length() > 2 ? headers.substring(0, headers.length() - 2) : "",
                 body.isBlank() ? "" : " | Body: " + body);
 
         if (status >= 400) {


### PR DESCRIPTION
## Summary

- `logResponse` 메서드에 응답 헤더 수집 및 로깅 로직 추가
- 요청 헤더 로깅 형식(`logRequest`)과 동일한 방식으로 구현

## Changes

**`RequestResponseLoggingFilter.java`**
- `response.getHeaderNames()`로 응답 헤더 수집
- 로그 포맷에 `Headers: [...]` 추가

## Log Output (Before / After)

**Before**
```
[abc123] <<< GET /api/users | Status: 200 | 42ms | Body: {...}
```

**After**
```
[abc123] <<< GET /api/users | Status: 200 | 42ms | Headers: [Content-Type: application/json, ...] | Body: {...}
```

Closes #36